### PR TITLE
Make it easier to get to the Xamarin.Forms control from the Blazor component

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/Elements/ActivityIndicator.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ActivityIndicator.cs
@@ -19,6 +19,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public bool? IsRunning { get; set; }
         [Parameter] public XF.Color? Color { get; set; }
 
+        public new XF.ActivityIndicator NativeControl => ((ActivityIndicatorHandler)ElementHandler).ActivityIndicatorControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseMenuItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseMenuItem.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
 namespace Microsoft.MobileBlazorBindings.Elements
 {
     public abstract class BaseMenuItem : Element
     {
+        public new XF.BaseMenuItem NativeControl => ((BaseMenuItemHandler)ElementHandler).BaseMenuItemControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.cs
@@ -27,6 +27,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public EventCallback OnAppearing { get; set; }
         [Parameter] public EventCallback OnDisappearing { get; set; }
 
+        public new XF.BaseShellItem NativeControl => ((BaseShellItemHandler)ElementHandler).BaseShellItemControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Button.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Button.cs
@@ -21,6 +21,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public EventCallback OnClick { get; set; }
 
+        public new XF.Button NativeControl => ((ButtonHandler)ElementHandler).ButtonControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentPage.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentPage.cs
@@ -14,5 +14,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
             ElementHandlerRegistry
                .RegisterElementHandler<ContentPage>(renderer => new ContentPageHandler(renderer, new XF.ContentPage()));
         }
+
+        public new XF.ContentPage NativeControl => ((ContentPageHandler)ElementHandler).ContentPageControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentView.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public RenderFragment ChildContent { get; set; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
+        public new XF.ContentView NativeControl => ((ContentViewHandler)ElementHandler).ContentViewControl;
+
         protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Element.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Element.cs
@@ -3,12 +3,15 @@
 
 using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.AspNetCore.Components;
+using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
     public abstract class Element : NativeControlComponentBase
     {
         [Parameter] public string StyleId { get; set; }
+
+        public XF.Element NativeControl => ((Handlers.ElementHandler)ElementHandler).ElementControl;
 
         protected override void RenderAttributes(AttributesBuilder builder)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Entry.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Entry.cs
@@ -23,6 +23,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public EventCallback OnCompleted { get; set; }
         [Parameter] public EventCallback<string> TextChanged { get; set; }
 
+        public new XF.Entry NativeControl => ((EntryHandler)ElementHandler).EntryControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/FlyoutItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FlyoutItem.cs
@@ -14,5 +14,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
             ElementHandlerRegistry.RegisterElementHandler<FlyoutItem>(
                 renderer => new FlyoutItemHandler(renderer, new XF.FlyoutItem()));
         }
+
+        public new XF.FlyoutItem NativeControl => ((FlyoutItemHandler)ElementHandler).FlyoutItemControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/FormattedString.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FormattedString.cs
@@ -18,6 +18,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public RenderFragment Spans { get; set; }
 
+        public new XF.FormattedString NativeControl => ((FormattedStringHandler)ElementHandler).FormattedStringControl;
+
         protected override RenderFragment GetChildContent() => Spans;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Frame.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Frame.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public XF.Color? BorderColor { get; set; }
         [Parameter] public float? CornerRadius { get; set; }
 
+        public new XF.Frame NativeControl => ((FrameHandler)ElementHandler).FrameControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/GestureElement.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/GestureElement.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
 namespace Microsoft.MobileBlazorBindings.Elements
 {
     public class GestureElement : Element
     {
+        public new XF.GestureElement NativeControl => ((GestureElementHandler)ElementHandler).GestureElementControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Grid.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Grid.cs
@@ -38,6 +38,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public RenderFragment Contents { get; set; }
         [Parameter] public RenderFragment Layout { get; set; }
 
+        public new XF.Grid NativeControl => ((GridHandler)ElementHandler).GridControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Image.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Image.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public bool? IsOpaque { get; set; }
         [Parameter] public XF.ImageSource Source { get; set; }
 
+        public new XF.Image NativeControl => ((ImageHandler)ElementHandler).ImageControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/InputView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/InputView.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.AspNetCore.Components;
+using XF = Xamarin.Forms;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
@@ -12,6 +14,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public bool? IsSpellCheckEnabled { get; set; }
         //[Parameter] public XF.Keyboard Keyboard { get; set; }
         [Parameter] public int? MaxLength { get; set; }
+
+        public new XF.InputView NativeControl => ((InputViewHandler)ElementHandler).InputViewControl;
 
         protected override void RenderAttributes(AttributesBuilder builder)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Label.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Label.cs
@@ -26,6 +26,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public RenderFragment FormattedText { get; set; }
 
+        public new XF.Layout NativeControl => ((LayoutHandler)ElementHandler).LayoutControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Layout.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Layout.cs
@@ -4,6 +4,7 @@
 using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.AspNetCore.Components;
 using XF = Xamarin.Forms;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
@@ -12,6 +13,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 #pragma warning restore CA1724 // Type name matches .NET Framework namespace
     {
         [Parameter] public XF.Thickness? Padding { get; set; }
+
+        public new XF.Layout NativeControl => ((LayoutHandler)ElementHandler).LayoutControl;
 
         protected override void RenderAttributes(AttributesBuilder builder)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/MasterDetailPage.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MasterDetailPage.cs
@@ -23,6 +23,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public RenderFragment Master { get; set; }
         [Parameter] public RenderFragment Detail { get; set; }
 
+        public new XF.MasterDetailPage NativeControl => ((MasterDetailPageHandler)ElementHandler).MasterDetailPageControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.cs
@@ -24,6 +24,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public EventCallback OnClick { get; set; }
 
+        public new XF.MenuItem NativeControl => ((MenuItemHandler)ElementHandler).MenuItemControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.cs
@@ -5,6 +5,7 @@ using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.AspNetCore.Components;
 using Microsoft.MobileBlazorBindings.Elements.Handlers;
 using System.Threading.Tasks;
+using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
@@ -14,6 +15,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         /// A comma-separated list of style classes that should be applied to this element.
         /// </summary>
         [Parameter] public string StyleClass { get; set; }
+
+        public new XF.NavigableElement NativeControl => ((NavigableElementHandler)ElementHandler).NavigableElementControl;
 
         protected override void RenderAttributes(AttributesBuilder builder)
         {
@@ -27,7 +30,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         public async Task PopModalAsync(bool animated = true)
         {
-            await ((NavigableElementHandler)ElementHandler).NavigableElementControl.Navigation.PopModalAsync(animated).ConfigureAwait(true);
+            await NativeControl.Navigation.PopModalAsync(animated).ConfigureAwait(true);
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
@@ -23,6 +23,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public RenderFragment ChildContent { get; set; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
+        public new XF.Page NativeControl => ((PageHandler)ElementHandler).PageControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.cs
@@ -23,6 +23,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public XF.ScrollOrientation? Orientation { get; set; }
         [Parameter] public XF.ScrollBarVisibility? VerticalScrollBarVisibility { get; set; }
 
+        public new XF.ScrollView NativeControl => ((ScrollViewHandler)ElementHandler).ScrollViewControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Shell.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Shell.cs
@@ -37,6 +37,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public EventCallback<XF.ShellNavigatedEventArgs> OnNavigated { get; set; }
         [Parameter] public EventCallback<XF.ShellNavigatingEventArgs> OnNavigating { get; set; }
 
+        public new XF.Shell NativeControl => ((ShellHandler)ElementHandler).ShellControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);
@@ -84,7 +86,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 throw new ArgumentNullException(nameof(state));
             }
 
-            await ((ShellHandler)ElementHandler).ShellControl.GoToAsync(state, animate).ConfigureAwait(true);
+            await NativeControl.GoToAsync(state, animate).ConfigureAwait(true);
         }
 
 #pragma warning disable CA1721 // Property names should not match get methods

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public RenderFragment ChildContent { get; set; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
+        public new XF.ShellContent NativeControl => ((ShellContentHandler)ElementHandler).ShellContentControl;
+
         protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellGroupItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellGroupItem.cs
@@ -18,6 +18,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public XF.FlyoutDisplayOptions? FlyoutDisplayOptions { get; set; }
 
+        public new XF.ShellGroupItem NativeControl => ((ShellGroupItemHandler)ElementHandler).ShellGroupItemControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public RenderFragment ChildContent { get; set; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
+        public new XF.ShellGroupItem NativeControl => ((ShellGroupItemHandler)ElementHandler).ShellGroupItemControl;
+
         protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.cs
@@ -20,6 +20,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public RenderFragment ChildContent { get; set; }
 #pragma warning restore CA1721 // Property names should not match get methods
 
+        public new XF.ShellSection NativeControl => ((ShellSectionHandler)ElementHandler).ShellSectionControl;
+
         protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Span.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Span.cs
@@ -23,6 +23,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public XF.Color? TextColor { get; set; }
         [Parameter] public XF.TextDecorations? TextDecorations { get; set; }
 
+        public new XF.Span NativeControl => ((SpanHandler)ElementHandler).SpanControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.cs
@@ -22,6 +22,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public XF.StackOrientation? Orientation { get; set; }
         [Parameter] public double? Spacing { get; set; }
 
+        public new XF.StackLayout NativeControl => ((StackLayoutHandler)ElementHandler).StackLayoutControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Stepper.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Stepper.cs
@@ -24,6 +24,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public EventCallback<double> ValueChanged { get; set; }
 
+        public new XF.Stepper NativeControl => ((StepperHandler)ElementHandler).StepperControl;
+        
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Switch.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Switch.cs
@@ -21,6 +21,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public EventCallback<bool> IsToggledChanged { get; set; }
 
+        public new XF.Switch NativeControl => ((SwitchHandler)ElementHandler).SwitchControl;
+
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             base.RenderAttributes(builder);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Tab.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Tab.cs
@@ -14,5 +14,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
             ElementHandlerRegistry.RegisterElementHandler<Tab>(
                 renderer => new TabHandler(renderer, new XF.Tab()));
         }
+
+        public new XF.Tab NativeControl => ((TabHandler)ElementHandler).TabControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TabBar.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TabBar.cs
@@ -14,5 +14,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
             ElementHandlerRegistry.RegisterElementHandler<TabBar>(
                 renderer => new TabBarHandler(renderer, new XF.TabBar()));
         }
+
+        public new XF.TabBar NativeControl => ((TabBarHandler)ElementHandler).TabBarControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TabbedPage.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TabbedPage.cs
@@ -14,5 +14,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
             ElementHandlerRegistry
                 .RegisterElementHandler<TabbedPage>(renderer => new TabbedPageHandler(renderer, new XF.TabbedPage()));
         }
+
+        public new XF.TabbedPage NativeControl => ((TabbedPageHandler)ElementHandler).TabbedPageControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TemplatedPage.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TemplatedPage.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
 namespace Microsoft.MobileBlazorBindings.Elements
 {
     public class TemplatedPage : Page
     {
+        public new XF.TemplatedPage NativeControl => ((TemplatedPageHandler)ElementHandler).TemplatedPageControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/TemplatedView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/TemplatedView.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
 namespace Microsoft.MobileBlazorBindings.Elements
 {
     public class TemplatedView : Layout
     {
         // TODO: Look in the future how to support a ControlTemplate:
         // https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/templates/control-templates/creating
+
+        public new XF.TemplatedView NativeControl => ((TemplatedViewHandler)ElementHandler).TemplatedViewControl;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/View.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/View.cs
@@ -4,6 +4,7 @@
 using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.AspNetCore.Components;
 using XF = Xamarin.Forms;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
@@ -12,6 +13,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public XF.LayoutOptions? HorizontalOptions { get; set; }
         [Parameter] public XF.Thickness? Margin { get; set; }
         [Parameter] public XF.LayoutOptions? VerticalOptions { get; set; }
+
+        public new XF.View NativeControl => ((ViewHandler)ElementHandler).ViewControl;
 
         protected override void RenderAttributes(AttributesBuilder builder)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
@@ -4,6 +4,7 @@
 using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.AspNetCore.Components;
 using XF = Xamarin.Forms;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
@@ -34,6 +35,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public EventCallback<XF.FocusEventArgs> OnFocused { get; set; }
         [Parameter] public EventCallback OnSizeChanged { get; set; }
         [Parameter] public EventCallback<XF.FocusEventArgs> OnUnfocused { get; set; }
+
+        public new XF.VisualElement NativeControl => ((VisualElementHandler)ElementHandler).VisualElementControl;
 
         protected override void RenderAttributes(AttributesBuilder builder)
         {


### PR DESCRIPTION
You can now do this to access the native Xamarin.Forms control

```xml
<StackLayout>
    <Label Text="@("You have pressed " + counter + " times")" />
    <Button @ref="incrementButton" Text="+1" OnClick="HandleClick" />
</StackLayout>

@code {
    Microsoft.MobileBlazorBindings.Elements.Button incrementButton;

    int counter;

    async Task HandleClick()
    {
        counter++;

        await incrementButton.NativeControl.RotateTo(360);
        incrementButton.NativeControl.Rotation = 0; // Reset rotation
    }
}
```

The `NativeControl` property on a given Blazor component is strongly-typed to its target Xamarin.Forms type. You can then call methods, set properties, etc.

A word of caution: Changing state in this manner is *not* tracked by Blazor, which can cause problems. For example, if you set the `Text` of a Label control in this manner, it will mess up Blazor's behavior. Use this only when you need to alter some native UI state, such as controlling an animation, or calling methods that affect some more global state.

Fixes #39