### PR TITLE
Add MobileBlazorBindingsHost that works on all platforms

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHost.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHost.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.IO;
+
+namespace Microsoft.MobileBlazorBindings
+{
+    public static class MobileBlazorBindingsHost
+    {
+        public static IHostBuilder CreateDefaultBuilder()
+        {
+            // Inspired by Microsoft.Extensions.Hosting.Host, which can be seen here:
+            // https://github.com/dotnet/extensions/blob/master/src/Hosting/Hosting/src/Host.cs
+            // But slightly modified to work on all of Android, iOS, and UWP.
+
+            var builder = new HostBuilder();
+
+            builder.UseContentRoot(Directory.GetCurrentDirectory());
+
+            builder.ConfigureLogging((hostingContext, logging) =>
+            {
+                logging.AddConsole(configure => configure.DisableColors = true);
+                logging.AddDebug();
+                logging.AddEventSourceLogger();
+            })
+            .UseDefaultServiceProvider((context, options) =>
+            {
+                var isDevelopment = context.HostingEnvironment.IsDevelopment();
+                options.ValidateScopes = isDevelopment;
+                options.ValidateOnBuild = isDevelopment;
+            });
+
+            return builder;
+        }
+    }
+}

--- a/templates/MobileBlazorBindings-app/NewApp/App.cs
+++ b/templates/MobileBlazorBindings-app/NewApp/App.cs
@@ -9,7 +9,7 @@ namespace NewApp
     {
         public App()
         {
-            var host = Host.CreateDefaultBuilder()
+            var host = MobileBlazorBindingsHost.CreateDefaultBuilder()
                 .ConfigureServices((hostContext, services) =>
                 {
                     // Register app-specific services


### PR DESCRIPTION
- In particular, it removes some configuration and logging stuff that's in the default Host

Fixes #30