### PR TITLE
Fix src work if NETCore3.0 not installed

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "3.0.100",
-	"rollForward": "minor"
+    "rollForward": "minor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100"
+    "version": "3.0.100",
+	"rollForward": "minor"
   }
 }


### PR DESCRIPTION
If you have installed .NET Core 3.1 but not 3.0 the source wouldn't load inside Visual Studio. By adding "rollForward": "minor" to global.json file, Visual Studio could find the 3.1 SDK. 
https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward

**The source rebuilt successfully with .NET Core SDK 3.1.**