### PR TITLE
Multi-direction support for Visual Element (RTL, LTR)

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.cs
@@ -107,6 +107,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.VisualElement.WidthRequest):
                     VisualElementControl.WidthRequest = AttributeHelper.StringToDouble((string)attributeValue);
                     break;
+                case nameof(XF.VisualElement.FlowDirection):
+                    VisualElementControl.FlowDirection = (XF.FlowDirection)AttributeHelper.GetInt(attributeValue);
+                    break;
                 case "onfocused":
                     Renderer.RegisterEvent(attributeEventHandlerId, () => FocusedEventHandlerId = 0);
                     FocusedEventHandlerId = attributeEventHandlerId;

--- a/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
@@ -31,7 +31,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public double? TranslationX { get; set; }
         [Parameter] public double? TranslationY { get; set; }
         [Parameter] public double? WidthRequest { get; set; }
-
+        [Parameter] public XF.FlowDirection? FlowDirection { get; set; }
         [Parameter] public EventCallback<XF.FocusEventArgs> OnFocused { get; set; }
         [Parameter] public EventCallback OnSizeChanged { get; set; }
         [Parameter] public EventCallback<XF.FocusEventArgs> OnUnfocused { get; set; }
@@ -125,6 +125,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             if (WidthRequest != null)
             {
                 builder.AddAttribute(nameof(WidthRequest), AttributeHelper.DoubleToString(WidthRequest.Value));
+            }
+            if (FlowDirection != null)
+            {
+                builder.AddAttribute(nameof(FlowDirection), (int)FlowDirection.Value);
             }
 
             builder.AddAttribute("onfocused", OnFocused);

--- a/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
@@ -13,6 +13,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public double? AnchorX { get; set; }
         [Parameter] public double? AnchorY { get; set; }
         [Parameter] public XF.Color? BackgroundColor { get; set; }
+        [Parameter] public XF.FlowDirection? FlowDirection { get; set; }
         [Parameter] public double? HeightRequest { get; set; }
         [Parameter] public bool? InputTransparent { get; set; }
         [Parameter] public bool? IsEnabled { get; set; }
@@ -31,7 +32,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public double? TranslationX { get; set; }
         [Parameter] public double? TranslationY { get; set; }
         [Parameter] public double? WidthRequest { get; set; }
-        [Parameter] public XF.FlowDirection? FlowDirection { get; set; }
+
         [Parameter] public EventCallback<XF.FocusEventArgs> OnFocused { get; set; }
         [Parameter] public EventCallback OnSizeChanged { get; set; }
         [Parameter] public EventCallback<XF.FocusEventArgs> OnUnfocused { get; set; }
@@ -53,6 +54,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             if (BackgroundColor != null)
             {
                 builder.AddAttribute(nameof(BackgroundColor), AttributeHelper.ColorToString(BackgroundColor.Value));
+            }
+            if (FlowDirection != null)
+            {
+                builder.AddAttribute(nameof(FlowDirection), (int)FlowDirection.Value);
             }
             if (HeightRequest != null)
             {
@@ -125,10 +130,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
             if (WidthRequest != null)
             {
                 builder.AddAttribute(nameof(WidthRequest), AttributeHelper.DoubleToString(WidthRequest.Value));
-            }
-            if (FlowDirection != null)
-            {
-                builder.AddAttribute(nameof(FlowDirection), (int)FlowDirection.Value);
             }
 
             builder.AddAttribute("onfocused", OnFocused);


### PR DESCRIPTION
In Xamarin Forms, every VisualElement has a property called FlowDirection. In MobileBlazorBindings, we need to expose this property to make it more multi-cultural. As a sample, this can be done like the following:

```
<TabbedPage FlowDirection="FlowDirection.RightToLeft">
    <ContentPage Title="Todo">
        <StackLayout>
            <Label FontSize="20" TextColor="Color.Crimson" Text="Todo Items" HorizontalTextAlignment="TextAlignment.Center" />
            <TodoList />
        </StackLayout>
    </ContentPage>
    <ContentPage Title="Counter">
        <Counter />
    </ContentPage>
    <ContentPage Title="About">
        <About />
    </ContentPage>
</TabbedPage>
```

This PR related to issue #58 

An example of RTL UI:
![Screenshot_1579775303](https://user-images.githubusercontent.com/57097646/72977933-cb846000-3dd5-11ea-90d8-948c44a2daff.png)



