### PR TITLE
Fix a million things in the component generator

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/Elements/AttributeHelper.Color.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/AttributeHelper.Color.cs
@@ -23,17 +23,21 @@ namespace Microsoft.MobileBlazorBindings.Elements
         /// <summary>
         /// Helper method to deserialize <see cref="Color" /> objects.
         /// </summary>
-        public static Color StringToColor(string colorString, Color defaultValueIfNull = default)
+        public static Color StringToColor(object colorString, Color defaultValueIfNull = default)
         {
             if (colorString is null)
             {
                 return defaultValueIfNull;
             }
-            if (colorString?.Length != 8)
+            if (!(colorString is string colorAsString))
+            {
+                throw new ArgumentException("Expected parameter instance to be a string.", nameof(colorString));
+            }
+            if (colorAsString?.Length != 8)
             {
                 throw new ArgumentException($"Invalid color string '{colorString}'. Expected a hex color in the form 'AARRGGBB'.", nameof(colorString));
             }
-            return FromHex(colorString);
+            return FromHex(colorAsString);
         }
 
         private static Color FromHex(string hex)

--- a/src/Microsoft.MobileBlazorBindings/Elements/AttributeHelper.ImageSource.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/AttributeHelper.ImageSource.cs
@@ -33,21 +33,25 @@ namespace Microsoft.MobileBlazorBindings.Elements
         /// <summary>
         /// Helper method to deserialize <see cref="ImageSource" /> objects.
         /// </summary>
-        public static ImageSource StringToImageSource(string imageSourceString, ImageSource defaultValueIfNull = default)
+        public static ImageSource StringToImageSource(object imageSourceString, ImageSource defaultValueIfNull = default)
         {
             if (imageSourceString is null)
             {
                 return defaultValueIfNull;
             }
+            if (!(imageSourceString is string imageSourceAsString))
+            {
+                throw new ArgumentException("Expected parameter instance to be a string.", nameof(imageSourceString));
+            }
 
-            var indexOfColon = imageSourceString.IndexOf(':');
+            var indexOfColon = imageSourceAsString.IndexOf(':');
             if (indexOfColon == -1)
             {
                 throw new ArgumentException($"Invalid image source format: '{imageSourceString}'", nameof(imageSourceString));
             }
 
-            var prefix = imageSourceString.Substring(0, indexOfColon);
-            var data = imageSourceString.Substring(indexOfColon + 1);
+            var prefix = imageSourceAsString.Substring(0, indexOfColon);
+            var data = imageSourceAsString.Substring(indexOfColon + 1);
 
             return prefix switch
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Element.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Element.cs
@@ -10,6 +10,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
     public abstract class Element : NativeControlComponentBase
     {
         [Parameter] public string AutomationId { get; set; }
+        [Parameter] public string ClassId { get; set; }
         [Parameter] public string StyleId { get; set; }
 
         public XF.Element NativeControl => ((Handlers.ElementHandler)ElementHandler).ElementControl;
@@ -21,6 +22,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             if (AutomationId != null)
             {
                 builder.AddAttribute(nameof(AutomationId), AutomationId);
+            }
+            if (ClassId != null)
+            {
+                builder.AddAttribute(nameof(ClassId), ClassId);
             }
             if (StyleId != null)
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ElementHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ElementHandler.cs
@@ -26,6 +26,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.Element.AutomationId):
                     ElementControl.AutomationId = (string)attributeValue;
                     break;
+                case nameof(XF.Element.ClassId):
+                    ElementControl.ClassId = (string)attributeValue;
+                    break;
                 case nameof(XF.Element.StyleId):
                     ElementControl.StyleId = (string)attributeValue;
                     break;


### PR DESCRIPTION
Aside from many fixes for odds and ends and special cases, the idea is now that the generator creates partial classes with some partial methods so that additional custom behavior can be added manually in a hand-written partial class. Aside from these manual customizations, the generated code is nearly identical to the previously hand-written code (aside from it fixing several pre-existing typos!).
