### PR TITLE
Split all generatable code into generated/custom files

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.Custom.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class BaseShellItem : NavigableElement
+    {
+        [Parameter] public EventCallback OnAppearing { get; set; }
+        [Parameter] public EventCallback OnDisappearing { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onappearing", OnAppearing);
+            builder.AddAttribute("ondisappearing", OnDisappearing);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BaseShellItem.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class BaseShellItem : NavigableElement
+    public partial class BaseShellItem : NavigableElement
     {
         static BaseShellItem()
         {
@@ -23,9 +23,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public string Route { get; set; }
         [Parameter] public string Title { get; set; }
         [Parameter] public int? TabIndex { get; set; }
-
-        [Parameter] public EventCallback OnAppearing { get; set; }
-        [Parameter] public EventCallback OnDisappearing { get; set; }
 
         public new XF.BaseShellItem NativeControl => ((BaseShellItemHandler)ElementHandler).BaseShellItemControl;
 
@@ -62,8 +59,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(TabIndex), TabIndex.Value);
             }
 
-            builder.AddAttribute("onappearing", OnAppearing);
-            builder.AddAttribute("ondisappearing", OnDisappearing);
+            RenderAdditionalAttributes(builder);
         }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Button.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Button.Custom.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Button : View
+    {
+        [Parameter] public EventCallback OnClick { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onclick", OnClick);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Button.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Button.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Button : View
+    public partial class Button : View
     {
         static Button()
         {
@@ -18,8 +18,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public string Text { get; set; }
         [Parameter] public XF.Color? TextColor { get; set; }
-
-        [Parameter] public EventCallback OnClick { get; set; }
 
         public new XF.Button NativeControl => ((ButtonHandler)ElementHandler).ButtonControl;
 
@@ -36,7 +34,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(TextColor), AttributeHelper.ColorToString(TextColor.Value));
             }
 
-            builder.AddAttribute("onclick", OnClick);
+            RenderAdditionalAttributes(builder);
         }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentView.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentView.Custom.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ContentView : TemplatedView
+    {
+#pragma warning disable CA1721 // Property names should not match get methods
+        [Parameter] public RenderFragment ChildContent { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        protected override RenderFragment GetChildContent() => ChildContent;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ContentView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ContentView.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class ContentView : TemplatedView
+    public partial class ContentView : TemplatedView
     {
         static ContentView()
         {
@@ -16,12 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 renderer => new ContentViewHandler(renderer, new XF.ContentView()));
         }
 
-#pragma warning disable CA1721 // Property names should not match get methods
-        [Parameter] public RenderFragment ChildContent { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
-
         public new XF.ContentView NativeControl => ((ContentViewHandler)ElementHandler).ContentViewControl;
-
-        protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Entry.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Entry.Custom.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Entry : InputView
+    {
+        [Parameter] public EventCallback OnCompleted { get; set; }
+        [Parameter] public EventCallback<string> TextChanged { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("oncompleted", OnCompleted);
+            builder.AddAttribute("ontextchanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleTextChanged));
+        }
+
+        private Task HandleTextChanged(ChangeEventArgs evt)
+        {
+            return TextChanged.InvokeAsync((string)evt.Value);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Entry.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Entry.cs
@@ -9,7 +9,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Entry : InputView
+    public partial class Entry : InputView
     {
         static Entry()
         {
@@ -35,9 +35,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public string Text { get; set; }
         [Parameter] public XF.Color? TextColor { get; set; }
         [Parameter] public XF.TextAlignment? VerticalTextAlignment { get; set; }
-
-        [Parameter] public EventCallback OnCompleted { get; set; }
-        [Parameter] public EventCallback<string> TextChanged { get; set; }
 
         public new XF.Entry NativeControl => ((EntryHandler)ElementHandler).EntryControl;
 
@@ -110,13 +107,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(VerticalTextAlignment), (int)VerticalTextAlignment);
             }
 
-            builder.AddAttribute("oncompleted", OnCompleted);
-            builder.AddAttribute("ontextchanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleTextChanged));
+            RenderAdditionalAttributes(builder);
         }
 
-        private Task HandleTextChanged(ChangeEventArgs evt)
-        {
-            return TextChanged.InvokeAsync((string)evt.Value);
-        }
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/FormattedString.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FormattedString.Custom.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class FormattedString : Element
+    {
+        [Parameter] public RenderFragment Spans { get; set; }
+
+        protected override RenderFragment GetChildContent() => Spans;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/FormattedString.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/FormattedString.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class FormattedString : Element
+    public partial class FormattedString : Element
     {
         static FormattedString()
         {
@@ -16,10 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 .RegisterElementHandler<FormattedString>(renderer => new FormattedStringHandler(renderer, new XF.FormattedString()));
         }
 
-        [Parameter] public RenderFragment Spans { get; set; }
-
         public new XF.FormattedString NativeControl => ((FormattedStringHandler)ElementHandler).FormattedStringControl;
-
-        protected override RenderFragment GetChildContent() => Spans;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Grid.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Grid.Custom.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Elements.GridInternals;
+using System;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Grid : Layout
+    {
+        public Grid()
+        {
+            GridMetadata = new GridMetadata();
+            GridMetadata.StateHasChanged += OnGridMetadataStateHasChanged;
+        }
+
+        private void OnGridMetadataStateHasChanged(object sender, EventArgs e)
+        {
+            StateHasChanged();
+        }
+
+        private GridMetadata GridMetadata { get; } // Used as a CascadingValue for certain child components, such as Row/Column definitions
+
+        // TODO: Maybe replace all this with ChildContents. All handling will probably go directly to the grid anyway
+        [Parameter] public RenderFragment Contents { get; set; }
+        [Parameter] public RenderFragment Layout { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute(nameof(GridMetadata), System.Text.Json.JsonSerializer.Serialize(GridMetadata));
+        }
+
+        protected override RenderFragment GetChildContent() => builder =>
+        {
+            builder.OpenComponent<CascadingValue<GridMetadata>>(0);
+            builder.AddAttribute(1, nameof(CascadingValue<GridMetadata>.Value), GridMetadata);
+
+            builder.AddAttribute(2, nameof(CascadingValue<GridMetadata>.ChildContent), (RenderFragment)(builder =>
+            {
+                builder.AddContent(0, Layout);
+            }));
+
+            builder.CloseComponent(); // CascadingValue<GridMetadata>
+
+            builder.AddContent(1, Contents);
+        };
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Grid.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Grid.cs
@@ -10,7 +10,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Grid : Layout
+    public partial class Grid : Layout
     {
         static Grid()
         {
@@ -18,25 +18,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 .RegisterElementHandler<Grid>(renderer => new GridHandler(renderer, new XF.Grid()));
         }
 
-        public Grid()
-        {
-            GridMetadata = new GridMetadata();
-            GridMetadata.StateHasChanged += OnGridMetadataStateHasChanged;
-        }
-
-        private void OnGridMetadataStateHasChanged(object sender, EventArgs e)
-        {
-            StateHasChanged();
-        }
-
-        private GridMetadata GridMetadata { get; } // Used as a CascadingValue for certain child components, such as Row/Column definitions
-
         [Parameter] public double? ColumnSpacing { get; set; }
         [Parameter] public double? RowSpacing { get; set; }
-
-        // TODO: Maybe replace all this with ChildContents. All handling will probably go directly to the grid anyway
-        [Parameter] public RenderFragment Contents { get; set; }
-        [Parameter] public RenderFragment Layout { get; set; }
 
         public new XF.Grid NativeControl => ((GridHandler)ElementHandler).GridControl;
 
@@ -52,22 +35,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             {
                 builder.AddAttribute(nameof(RowSpacing), AttributeHelper.DoubleToString(RowSpacing.Value));
             }
-            builder.AddAttribute(nameof(GridMetadata), System.Text.Json.JsonSerializer.Serialize(GridMetadata));
+
+            RenderAdditionalAttributes(builder);
         }
 
-        protected override RenderFragment GetChildContent() => builder =>
-        {
-            builder.OpenComponent<CascadingValue<GridMetadata>>(0);
-            builder.AddAttribute(1, nameof(CascadingValue<GridMetadata>.Value), GridMetadata);
-
-            builder.AddAttribute(2, nameof(CascadingValue<GridMetadata>.ChildContent), (RenderFragment)(builder =>
-            {
-                builder.AddContent(0, Layout);
-            }));
-
-            builder.CloseComponent(); // CascadingValue<GridMetadata>
-
-            builder.AddContent(1, Contents);
-        };
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.Custom.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class BaseShellItemHandler : NavigableElementHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            BaseShellItemControl.Appearing += (s, e) =>
+            {
+                if (AppearingEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(AppearingEventHandlerId, null, e));
+                }
+            };
+            BaseShellItemControl.Disappearing += (s, e) =>
+            {
+                if (DisappearingEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(DisappearingEventHandlerId, null, e));
+                }
+            };
+        }
+
+        public ulong AppearingEventHandlerId { get; set; }
+        public ulong DisappearingEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "onappearing":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => AppearingEventHandlerId = 0);
+                    AppearingEventHandlerId = attributeEventHandlerId;
+                    break;
+                case "ondisappearing":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => DisappearingEventHandlerId = 0);
+                    DisappearingEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.cs
@@ -7,34 +7,26 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class BaseShellItemHandler : NavigableElementHandler
+    public partial class BaseShellItemHandler : NavigableElementHandler
     {
         public BaseShellItemHandler(NativeComponentRenderer renderer, XF.BaseShellItem baseShellItemControl) : base(renderer, baseShellItemControl)
         {
             BaseShellItemControl = baseShellItemControl ?? throw new ArgumentNullException(nameof(baseShellItemControl));
 
-            BaseShellItemControl.Appearing += (s, e) =>
-            {
-                if (AppearingEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(AppearingEventHandlerId, null, e));
-                }
-            };
-            BaseShellItemControl.Disappearing += (s, e) =>
-            {
-                if (DisappearingEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(DisappearingEventHandlerId, null, e));
-                }
-            };
+            Initialize(renderer);
         }
 
+        partial void Initialize(NativeComponentRenderer renderer);
+
         public XF.BaseShellItem BaseShellItemControl { get; }
-        public ulong AppearingEventHandlerId { get; set; }
-        public ulong DisappearingEventHandlerId { get; set; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(XF.BaseShellItem.FlyoutIcon):
@@ -58,19 +50,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.BaseShellItem.TabIndex):
                     BaseShellItemControl.TabIndex = AttributeHelper.GetInt(attributeValue);
                     break;
-
-                case "onappearing":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => AppearingEventHandlerId = 0);
-                    AppearingEventHandlerId = attributeEventHandlerId;
-                    break;
-                case "ondisappearing":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => DisappearingEventHandlerId = 0);
-                    DisappearingEventHandlerId = attributeEventHandlerId;
-                    break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.Custom.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class ButtonHandler : ViewHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            ButtonControl.Clicked += (s, e) =>
+            {
+                if (ClickEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ClickEventHandlerId, null, e));
+                }
+            };
+        }
+
+        public ulong ClickEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "onclick":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => ClickEventHandlerId = 0);
+                    ClickEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.cs
@@ -7,25 +7,26 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class ButtonHandler : ViewHandler
+    public partial class ButtonHandler : ViewHandler
     {
         public ButtonHandler(NativeComponentRenderer renderer, XF.Button buttonControl) : base(renderer, buttonControl)
         {
             ButtonControl = buttonControl ?? throw new ArgumentNullException(nameof(buttonControl));
-            ButtonControl.Clicked += (s, e) =>
-            {
-                if (ClickEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ClickEventHandlerId, null, e));
-                }
-            };
+
+            Initialize(renderer);
         }
 
+        partial void Initialize(NativeComponentRenderer renderer);
+
         public XF.Button ButtonControl { get; }
-        public ulong ClickEventHandlerId { get; set; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(Button.Text):
@@ -34,14 +35,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(Button.TextColor):
                     ButtonControl.TextColor = AttributeHelper.StringToColor((string)attributeValue);
                     break;
-                case "onclick":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => ClickEventHandlerId = 0);
-                    ClickEventHandlerId = attributeEventHandlerId;
-                    break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.Custom.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class EntryHandler : InputViewHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            EntryControl.Completed += (s, e) =>
+            {
+                if (CompletedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(CompletedEventHandlerId, null, e));
+                }
+            };
+            EntryControl.TextChanged += (s, e) =>
+            {
+                if (TextChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(TextChangedEventHandlerId, null, new ChangeEventArgs { Value = EntryControl.Text }));
+                }
+            };
+        }
+
+        public ulong CompletedEventHandlerId { get; set; }
+        public ulong TextChangedEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "oncompleted":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => CompletedEventHandlerId = 0);
+                    CompletedEventHandlerId = attributeEventHandlerId;
+                    break;
+                case "ontextchanged":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => TextChangedEventHandlerId = 0);
+                    TextChangedEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.cs
@@ -8,33 +8,26 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class EntryHandler : InputViewHandler
+    public partial class EntryHandler : InputViewHandler
     {
         public EntryHandler(NativeComponentRenderer renderer, XF.Entry entryControl) : base(renderer, entryControl)
         {
             EntryControl = entryControl ?? throw new ArgumentNullException(nameof(entryControl));
-            EntryControl.Completed += (s, e) =>
-            {
-                if (CompletedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(CompletedEventHandlerId, null, e));
-                }
-            };
-            EntryControl.TextChanged += (s, e) =>
-            {
-                if (TextChangedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(TextChangedEventHandlerId, null, new ChangeEventArgs { Value = EntryControl.Text }));
-                }
-            };
+
+            Initialize(renderer);
         }
 
-        public ulong CompletedEventHandlerId { get; set; }
-        public ulong TextChangedEventHandlerId { get; set; }
+        partial void Initialize(NativeComponentRenderer renderer);
+
         public XF.Entry EntryControl { get; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(XF.Entry.CharacterSpacing):
@@ -85,19 +78,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.Entry.VerticalTextAlignment):
                     EntryControl.VerticalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue);
                     break;
-
-                case "oncompleted":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => CompletedEventHandlerId = 0);
-                    CompletedEventHandlerId = attributeEventHandlerId;
-                    break;
-                case "ontextchanged":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => TextChangedEventHandlerId = 0);
-                    TextChangedEventHandlerId = attributeEventHandlerId;
-                    break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.Custom.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Elements.GridInternals;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class GridHandler : LayoutHandler
+    {
+        partial void ApplyGridMetadata(object attributeValue)
+        {
+            GridControl.RowDefinitions.Clear();
+            GridControl.ColumnDefinitions.Clear();
+            var gridMetadata = System.Text.Json.JsonSerializer.Deserialize<GridMetadataForDeserialization>((string)attributeValue);
+            foreach (var row in gridMetadata.RowDefinitions)
+            {
+                GridControl.RowDefinitions.Add(new XF.RowDefinition { Height = GetGridLength(row.Height, row.GridUnitType) });
+            }
+            foreach (var column in gridMetadata.ColumnDefinitions)
+            {
+                GridControl.ColumnDefinitions.Add(new XF.ColumnDefinition { Width = GetGridLength(column.Width, column.GridUnitType) });
+            }
+        }
+
+        private static XF.GridLength GetGridLength(double? length, XF.GridUnitType? gridUnitType)
+        {
+            if (!gridUnitType.HasValue)
+            {
+                gridUnitType = XF.GridUnitType.Absolute;
+            }
+            return gridUnitType.Value switch
+            {
+                XF.GridUnitType.Absolute => new XF.GridLength(length.Value),
+                XF.GridUnitType.Star => XF.GridLength.Star,
+                XF.GridUnitType.Auto => XF.GridLength.Auto,
+                _ => throw new ArgumentException("Arguments represent an invalid grid length."),
+            };
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.cs
@@ -2,23 +2,31 @@
 // Licensed under the MIT license.
 
 using Microsoft.MobileBlazorBindings.Core;
-using Microsoft.MobileBlazorBindings.Elements.GridInternals;
 using System;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class GridHandler : LayoutHandler
+    public partial class GridHandler : LayoutHandler
     {
         public GridHandler(NativeComponentRenderer renderer, XF.Grid gridControl) : base(renderer, gridControl)
         {
             GridControl = gridControl ?? throw new ArgumentNullException(nameof(gridControl));
+
+            Initialize(renderer);
         }
+
+        partial void Initialize(NativeComponentRenderer renderer);
 
         public XF.Grid GridControl { get; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(XF.Grid.ColumnSpacing):
@@ -27,18 +35,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.Grid.RowSpacing):
                     GridControl.RowSpacing = AttributeHelper.StringToDouble((string)attributeValue);
                     break;
-                case nameof(GridMetadata):
-                    GridControl.RowDefinitions.Clear();
-                    GridControl.ColumnDefinitions.Clear();
-                    var gridMetadata = System.Text.Json.JsonSerializer.Deserialize<GridMetadataForDeserialization>((string)attributeValue);
-                    foreach (var row in gridMetadata.RowDefinitions)
-                    {
-                        GridControl.RowDefinitions.Add(new XF.RowDefinition { Height = GetGridLength(row.Height, row.GridUnitType) });
-                    }
-                    foreach (var column in gridMetadata.ColumnDefinitions)
-                    {
-                        GridControl.ColumnDefinitions.Add(new XF.ColumnDefinition { Width = GetGridLength(column.Width, column.GridUnitType) });
-                    }
+                case nameof(GridInternals.GridMetadata):
+                    // TODO: Need a better long-term solution to this because this isn't compatible with generated code
+                    ApplyGridMetadata(attributeValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
@@ -46,19 +45,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        private static XF.GridLength GetGridLength(double? length, XF.GridUnitType? gridUnitType)
-        {
-            if (!gridUnitType.HasValue)
-            {
-                gridUnitType = XF.GridUnitType.Absolute;
-            }
-            return gridUnitType.Value switch
-            {
-                XF.GridUnitType.Absolute => new XF.GridLength(length.Value),
-                XF.GridUnitType.Star => XF.GridLength.Star,
-                XF.GridUnitType.Auto => XF.GridLength.Auto,
-                _ => throw new ArgumentException("Arguments represent an invalid grid length."),
-            };
-        }
+        partial void ApplyGridMetadata(object attributeValue);
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.Custom.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class MasterDetailPageHandler : PageHandler
+    {
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable CA1801 // Parameter is never used
+        partial void Initialize(NativeComponentRenderer renderer)
+#pragma warning restore CA1801 // Parameter is never used
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+            // Set dummy Master and Detail because this element cannot be parented unless both are set.
+            // https://github.com/xamarin/Xamarin.Forms/blob/ff63ef551d9b2b5736092eb48aaf954f54d63417/Xamarin.Forms.Core/MasterDetailPage.cs#L199
+            // In Blazor, parents are created before children, whereas this doesn't appear to be the case in
+            // Xamarin.Forms. Once the Blazor children get created, they will overwrite these dummy elements.
+
+            // The Master page must have its Title set:
+            // https://github.com/xamarin/Xamarin.Forms/blob/ff63ef551d9b2b5736092eb48aaf954f54d63417/Xamarin.Forms.Core/MasterDetailPage.cs#L72
+            MasterDetailPageControl.Master = new XF.Page() { Title = "Title" };
+            MasterDetailPageControl.Detail = new XF.Page();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.cs
@@ -7,22 +7,16 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class MasterDetailPageHandler : PageHandler
+    public partial class MasterDetailPageHandler : PageHandler
     {
         public MasterDetailPageHandler(NativeComponentRenderer renderer, XF.MasterDetailPage masterDetailPageControl) : base(renderer, masterDetailPageControl)
         {
             MasterDetailPageControl = masterDetailPageControl ?? throw new ArgumentNullException(nameof(masterDetailPageControl));
 
-            // Set dummy Master and Detail because this element cannot be parented unless both are set.
-            // https://github.com/xamarin/Xamarin.Forms/blob/ff63ef551d9b2b5736092eb48aaf954f54d63417/Xamarin.Forms.Core/MasterDetailPage.cs#L199
-            // In Blazor, parents are created before children, whereas this doesn't appear to be the case in
-            // Xamarin.Forms. Once the Blazor children get created, they will overwrite these dummy elements.
-
-            // The Master page must have its Title set:
-            // https://github.com/xamarin/Xamarin.Forms/blob/ff63ef551d9b2b5736092eb48aaf954f54d63417/Xamarin.Forms.Core/MasterDetailPage.cs#L72
-            MasterDetailPageControl.Master = new XF.Page() { Title = "Title" };
-            MasterDetailPageControl.Detail = new XF.Page();
+            Initialize(renderer);
         }
+
+        partial void Initialize(NativeComponentRenderer renderer);
 
         public XF.MasterDetailPage MasterDetailPageControl { get; }
 

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterPageHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterPageHandler.Custom.cs
@@ -2,26 +2,20 @@
 // Licensed under the MIT license.
 
 using Microsoft.MobileBlazorBindings.Core;
-using System;
-using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public sealed partial class MasterPageHandler : ContentPageHandler
     {
-        public MasterPageHandler(NativeComponentRenderer renderer, XF.ContentPage masterDetailPageControl) : base(renderer, masterDetailPageControl)
+#pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable CA1801 // Parameter is never used
+        partial void Initialize(NativeComponentRenderer renderer)
+#pragma warning restore CA1801 // Parameter is never used
+#pragma warning restore IDE0060 // Remove unused parameter
         {
-            MasterDetailPageControl = masterDetailPageControl ?? throw new ArgumentNullException(nameof(masterDetailPageControl));
-
             // The Master page must have its Title set:
             // https://github.com/xamarin/Xamarin.Forms/blob/ff63ef551d9b2b5736092eb48aaf954f54d63417/Xamarin.Forms.Core/MasterDetailPage.cs#L72
             ContentPageControl.Title = "Title";
-
-            Initialize(renderer);
         }
-
-        partial void Initialize(NativeComponentRenderer renderer);
-
-        public XF.ContentPage MasterDetailPageControl { get; }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.Custom.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class MenuItemHandler : BaseMenuItemHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            MenuItemControl.Clicked += (s, e) =>
+            {
+                if (ClickEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ClickEventHandlerId, null, e));
+                }
+            };
+        }
+
+        public ulong ClickEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "onclick":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => ClickEventHandlerId = 0);
+                    ClickEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.cs
@@ -7,25 +7,26 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class MenuItemHandler : BaseMenuItemHandler
+    public partial class MenuItemHandler : BaseMenuItemHandler
     {
         public MenuItemHandler(NativeComponentRenderer renderer, XF.MenuItem menuItemControl) : base(renderer, menuItemControl)
         {
             MenuItemControl = menuItemControl ?? throw new ArgumentNullException(nameof(menuItemControl));
-            MenuItemControl.Clicked += (s, e) =>
-            {
-                if (ClickEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ClickEventHandlerId, null, e));
-                }
-            };
+
+            Initialize(renderer);
         }
 
+        partial void Initialize(NativeComponentRenderer renderer);
+
         public XF.MenuItem MenuItemControl { get; }
-        public ulong ClickEventHandlerId { get; set; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(XF.MenuItem.IconImageSource):
@@ -37,14 +38,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.MenuItem.Text):
                     MenuItemControl.Text = (string)attributeValue;
                     break;
-                case "onclick":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => ClickEventHandlerId = 0);
-                    ClickEventHandlerId = attributeEventHandlerId;
-                    break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.Custom.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class ShellHandler : PageHandler
+    {
+        private readonly ShellContentMarkerItem _dummyShellContent = new ShellContentMarkerItem();
+        private readonly XF.ContentView _flyoutHeaderContentView = new XF.ContentView();
+
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            // Add one item for Shell to load correctly. It will later be removed when the first real
+            // item is added by the app.
+            ShellControl.Items.Add(_dummyShellContent);
+
+            // Add a dummy FlyoutHeader because it cannot be set dynamically later. When app code sets
+            // its own FlyoutHeader, it will be set as the Content of this ContentView.
+            // See https://github.com/xamarin/Xamarin.Forms/issues/6161 ([Bug] Changing the Shell Flyout Header after it's already rendered doesn't work)
+            _flyoutHeaderContentView.IsVisible = false;
+            ShellControl.FlyoutHeader = _flyoutHeaderContentView;
+
+            ShellControl.Navigated += (s, e) =>
+            {
+                if (NavigatedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(NavigatedEventHandlerId, null, e));
+                }
+            };
+            ShellControl.Navigating += (s, e) =>
+            {
+                if (NavigatingEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(NavigatingEventHandlerId, null, e));
+                }
+            };
+        }
+
+        internal bool ClearDummyChild()
+        {
+            // Remove the dummy ShellContent if it's still there. This won't throw even if the item is already removed.
+            return ShellControl.Items.Remove(_dummyShellContent);
+        }
+
+        public ulong NavigatedEventHandlerId { get; set; }
+        public ulong NavigatingEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "onnavigated":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => NavigatedEventHandlerId = 0);
+                    NavigatedEventHandlerId = attributeEventHandlerId;
+                    break;
+                case "onnavigating":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => NavigatingEventHandlerId = 0);
+                    NavigatingEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.cs
@@ -7,57 +7,28 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class ShellHandler : PageHandler
+    public partial class ShellHandler : PageHandler
     {
-        private readonly ShellContentMarkerItem _dummyShellContent = new ShellContentMarkerItem();
-        private readonly XF.ContentView _flyoutHeaderContentView = new XF.ContentView();
-
         public ShellHandler(NativeComponentRenderer renderer, XF.Shell shellControl) : base(renderer, shellControl)
         {
             ShellControl = shellControl ?? throw new ArgumentNullException(nameof(shellControl));
 
-            // Add one item for Shell to load correctly. It will later be removed when the first real
-            // item is added by the app.
-            ShellControl.Items.Add(_dummyShellContent);
-
-            // Add a dummy FlyoutHeader because it cannot be set dynamically later. When app code sets
-            // its own FlyoutHeader, it will be set as the Content of this ContentView.
-            // See https://github.com/xamarin/Xamarin.Forms/issues/6161 ([Bug] Changing the Shell Flyout Header after it's already rendered doesn't work)
-            _flyoutHeaderContentView.IsVisible = false;
-            ShellControl.FlyoutHeader = _flyoutHeaderContentView;
-
-            ShellControl.Navigated += (s, e) =>
-            {
-                if (NavigatedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(NavigatedEventHandlerId, null, e));
-                }
-            };
-            ShellControl.Navigating += (s, e) =>
-            {
-                if (NavigatingEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(NavigatingEventHandlerId, null, e));
-                }
-            };
+            Initialize(renderer);
         }
 
-        internal bool ClearDummyChild()
-        {
-            // Remove the dummy ShellContent if it's still there. This won't throw even if the item is already removed.
-            return ShellControl.Items.Remove(_dummyShellContent);
-        }
+        partial void Initialize(NativeComponentRenderer renderer);
 
         public XF.Shell ShellControl { get; }
-        public ulong NavigatedEventHandlerId { get; set; }
-        public ulong NavigatingEventHandlerId { get; set; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
-                //[Parameter] public ShellItem CurrentItem { get; set; }
-                //[Parameter] public ShellNavigationState CurrentState { get; }
                 case nameof(XF.Shell.FlyoutBackgroundImage):
                     ShellControl.FlyoutBackgroundImage = attributeValue == null ? null : AttributeHelper.StringToImageSource((string)attributeValue);
                     break;
@@ -73,26 +44,15 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.Shell.FlyoutHeaderBehavior):
                     ShellControl.FlyoutHeaderBehavior = (XF.FlyoutHeaderBehavior)AttributeHelper.GetInt(attributeValue);
                     break;
-                //[Parameter] public DataTemplate FlyoutHeaderTemplate { get; set; }
                 case nameof(XF.Shell.FlyoutIcon):
                     ShellControl.FlyoutIcon = attributeValue == null ? null : AttributeHelper.StringToImageSource((string)attributeValue);
-                    break;
-                //[Parameter] public bool? FlyoutIsPresented { get; set; } // TODO: Two-way binding?
-                //[Parameter] public DataTemplate ItemTemplate { get; set; }
-                //[Parameter] public DataTemplate MenuItemTemplate { get; set; }
-
-                case "onnavigated":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => NavigatedEventHandlerId = 0);
-                    NavigatedEventHandlerId = attributeEventHandlerId;
-                    break;
-                case "onnavigating":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => NavigatingEventHandlerId = 0);
-                    NavigatingEventHandlerId = attributeEventHandlerId;
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.Custom.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class StepperHandler : ViewHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            StepperControl.ValueChanged += (s, e) =>
+            {
+                if (ValueChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ValueChangedEventHandlerId, null, new ChangeEventArgs { Value = StepperControl.Value }));
+                }
+            };
+        }
+
+        public ulong ValueChangedEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "onvaluechanged":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => ValueChangedEventHandlerId = 0);
+                    ValueChangedEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.cs
@@ -2,31 +2,31 @@
 // Licensed under the MIT license.
 
 using Microsoft.MobileBlazorBindings.Core;
-using Microsoft.AspNetCore.Components;
 using System;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class StepperHandler : ViewHandler
+    public partial class StepperHandler : ViewHandler
     {
         public StepperHandler(NativeComponentRenderer renderer, XF.Stepper stepperControl) : base(renderer, stepperControl)
         {
             StepperControl = stepperControl ?? throw new ArgumentNullException(nameof(stepperControl));
-            StepperControl.ValueChanged += (s, e) =>
-            {
-                if (ValueChangedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ValueChangedEventHandlerId, null, new ChangeEventArgs { Value = StepperControl.Value }));
-                }
-            };
+
+            Initialize(renderer);
         }
 
-        public ulong ValueChangedEventHandlerId { get; set; }
+        partial void Initialize(NativeComponentRenderer renderer);
+
         public XF.Stepper StepperControl { get; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(XF.Stepper.Increment):
@@ -41,14 +41,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.Stepper.Value):
                     StepperControl.Value = AttributeHelper.StringToDouble((string)attributeValue);
                     break;
-                case "onvaluechanged":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => ValueChangedEventHandlerId = 0);
-                    ValueChangedEventHandlerId = attributeEventHandlerId;
-                    break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.Custom.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class SwitchHandler : ViewHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            SwitchControl.Toggled += (s, e) =>
+            {
+                if (IsToggledChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(IsToggledChangedEventHandlerId, null, new ChangeEventArgs { Value = SwitchControl.IsToggled }));
+                }
+            };
+        }
+
+        public ulong IsToggledChangedEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "onistoggledchanged":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => IsToggledChangedEventHandlerId = 0);
+                    IsToggledChangedEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.cs
@@ -2,43 +2,41 @@
 // Licensed under the MIT license.
 
 using Microsoft.MobileBlazorBindings.Core;
-using Microsoft.AspNetCore.Components;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class SwitchHandler : ViewHandler
+    public partial class SwitchHandler : ViewHandler
     {
         public SwitchHandler(NativeComponentRenderer renderer, XF.Switch switchControl) : base(renderer, switchControl)
         {
             SwitchControl = switchControl ?? throw new System.ArgumentNullException(nameof(switchControl));
-            SwitchControl.Toggled += (s, e) =>
-            {
-                if (IsToggledChangedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(IsToggledChangedEventHandlerId, null, new ChangeEventArgs { Value = SwitchControl.IsToggled }));
-                }
-            };
+
+            Initialize(renderer);
         }
 
-        public ulong IsToggledChangedEventHandlerId { get; set; }
+        partial void Initialize(NativeComponentRenderer renderer);
+
         public XF.Switch SwitchControl { get; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(XF.Switch.IsToggled):
                     SwitchControl.IsToggled = AttributeHelper.GetBool(attributeValue);
-                    break;
-                case "onistoggledchanged":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => IsToggledChangedEventHandlerId = 0);
-                    IsToggledChangedEventHandlerId = attributeEventHandlerId;
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.Custom.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class VisualElementHandler : NavigableElementHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            VisualElementControl.Focused += (s, e) =>
+            {
+                if (FocusedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(FocusedEventHandlerId, null, e));
+                }
+            };
+            VisualElementControl.SizeChanged += (s, e) =>
+            {
+                if (SizeChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(SizeChangedEventHandlerId, null, e));
+                }
+            };
+            VisualElementControl.Unfocused += (s, e) =>
+            {
+                if (UnfocusedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(UnfocusedEventHandlerId, null, e));
+                }
+            };
+        }
+
+        public ulong FocusedEventHandlerId { get; set; }
+        public ulong SizeChangedEventHandlerId { get; set; }
+        public ulong UnfocusedEventHandlerId { get; set; }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId)
+        {
+            switch (attributeName)
+            {
+                case "onfocused":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => FocusedEventHandlerId = 0);
+                    FocusedEventHandlerId = attributeEventHandlerId;
+                    break;
+                case "onsizechanged":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => SizeChangedEventHandlerId = 0);
+                    SizeChangedEventHandlerId = attributeEventHandlerId;
+                    break;
+                case "onunfocused":
+                    Renderer.RegisterEvent(attributeEventHandlerId, () => UnfocusedEventHandlerId = 0);
+                    UnfocusedEventHandlerId = attributeEventHandlerId;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.cs
@@ -7,41 +7,26 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class VisualElementHandler : NavigableElementHandler
+    public partial class VisualElementHandler : NavigableElementHandler
     {
         public VisualElementHandler(NativeComponentRenderer renderer, XF.VisualElement visualElementControl) : base(renderer, visualElementControl)
         {
             VisualElementControl = visualElementControl ?? throw new ArgumentNullException(nameof(visualElementControl));
-            VisualElementControl.Focused += (s, e) =>
-            {
-                if (FocusedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(FocusedEventHandlerId, null, e));
-                }
-            };
-            VisualElementControl.SizeChanged += (s, e) =>
-            {
-                if (SizeChangedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(SizeChangedEventHandlerId, null, e));
-                }
-            };
-            VisualElementControl.Unfocused += (s, e) =>
-            {
-                if (UnfocusedEventHandlerId != default)
-                {
-                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(UnfocusedEventHandlerId, null, e));
-                }
-            };
+
+            Initialize(renderer);
         }
 
+        partial void Initialize(NativeComponentRenderer renderer);
+
         public XF.VisualElement VisualElementControl { get; }
-        public ulong FocusedEventHandlerId { get; set; }
-        public ulong SizeChangedEventHandlerId { get; set; }
-        public ulong UnfocusedEventHandlerId { get; set; }
 
         public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
         {
+            if (attributeEventHandlerId != 0)
+            {
+                ApplyEventHandlerId(attributeName, attributeEventHandlerId);
+            }
+
             switch (attributeName)
             {
                 case nameof(XF.VisualElement.AnchorX):
@@ -110,22 +95,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 case nameof(XF.VisualElement.WidthRequest):
                     VisualElementControl.WidthRequest = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
                     break;
-                case "onfocused":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => FocusedEventHandlerId = 0);
-                    FocusedEventHandlerId = attributeEventHandlerId;
-                    break;
-                case "onsizechanged":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => SizeChangedEventHandlerId = 0);
-                    SizeChangedEventHandlerId = attributeEventHandlerId;
-                    break;
-                case "onunfocused":
-                    Renderer.RegisterEvent(attributeEventHandlerId, () => UnfocusedEventHandlerId = 0);
-                    UnfocusedEventHandlerId = attributeEventHandlerId;
-                    break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
                     break;
             }
         }
+
+        partial void ApplyEventHandlerId(string attributeName, ulong attributeEventHandlerId);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Label.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Label.Custom.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Label : View
+    {
+        [Parameter] public RenderFragment FormattedText { get; set; }
+
+        protected override RenderFragment GetChildContent() => FormattedText;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Label.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Label.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Label : View
+    public partial class Label : View
     {
         static Label()
         {
@@ -23,8 +23,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public XF.Color? TextColor { get; set; }
         [Parameter] public XF.TextDecorations? TextDecorations { get; set; }
         [Parameter] public XF.TextAlignment? VerticalTextAlignment { get; set; }
-
-        [Parameter] public RenderFragment FormattedText { get; set; }
 
         public new XF.Layout NativeControl => ((LayoutHandler)ElementHandler).LayoutControl;
 
@@ -60,8 +58,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             {
                 builder.AddAttribute(nameof(TextDecorations), (int)TextDecorations.Value);
             }
+
+            RenderAdditionalAttributes(builder);
         }
 
-        protected override RenderFragment GetChildContent() => FormattedText;
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/MasterDetailPage.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MasterDetailPage.Custom.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class MasterDetailPage : Page
+    {
+        [Parameter] public string MasterTitle { get; set; }
+
+        [Parameter] public RenderFragment Master { get; set; }
+        [Parameter] public RenderFragment Detail { get; set; }
+
+#pragma warning disable CA1721 // Property names should not match get methods
+        protected override RenderFragment GetChildContent() => RenderChildContent;
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        private void RenderChildContent(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<MasterDetailMasterPage>(0);
+            builder.AddAttribute(0, nameof(MasterDetailMasterPage.ChildContent), Master);
+            // TODO: This feels a bit hacky. This is really a property of the child control, but here we are defining
+            // it on the container control and applying it to the child. What about other such properties?
+            builder.AddAttribute(1, "Title", MasterTitle);
+            builder.CloseComponent();
+
+            builder.OpenComponent<MasterDetailDetailPage>(1);
+            builder.AddAttribute(0, nameof(MasterDetailDetailPage.ChildContent), Detail);
+            builder.CloseComponent();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/MasterDetailPage.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MasterDetailPage.cs
@@ -9,7 +9,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class MasterDetailPage : Page
+    public partial class MasterDetailPage : Page
     {
         static MasterDetailPage()
         {
@@ -17,11 +17,7 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 .RegisterElementHandler<MasterDetailPage>(renderer => new MasterDetailPageHandler(renderer, new XF.MasterDetailPage()));
         }
 
-        [Parameter] public string MasterTitle { get; set; }
         [Parameter] public XF.MasterBehavior? MasterBehavior { get; set; }
-
-        [Parameter] public RenderFragment Master { get; set; }
-        [Parameter] public RenderFragment Detail { get; set; }
 
         public new XF.MasterDetailPage NativeControl => ((MasterDetailPageHandler)ElementHandler).MasterDetailPageControl;
 
@@ -33,24 +29,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             {
                 builder.AddAttribute(nameof(MasterBehavior), (int)MasterBehavior.Value);
             }
+
+            RenderAdditionalAttributes(builder);
         }
 
-#pragma warning disable CA1721 // Property names should not match get methods
-        protected override RenderFragment GetChildContent() => RenderChildContent;
-#pragma warning restore CA1721 // Property names should not match get methods
-
-        private void RenderChildContent(RenderTreeBuilder builder)
-        {
-            builder.OpenComponent<MasterDetailMasterPage>(0);
-            builder.AddAttribute(0, nameof(MasterDetailMasterPage.ChildContent), Master);
-            // TODO: This feels a bit hacky. This is really a property of the child control, but here we are defining
-            // it on the container control and applying it to the child. What about other such properties?
-            builder.AddAttribute(1, "Title", MasterTitle);
-            builder.CloseComponent();
-
-            builder.OpenComponent<MasterDetailDetailPage>(1);
-            builder.AddAttribute(0, nameof(MasterDetailDetailPage.ChildContent), Detail);
-            builder.CloseComponent();
-        }
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.Custom.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class MenuItem : BaseMenuItem
+    {
+        [Parameter] public EventCallback OnClick { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onclick", OnClick);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/MenuItem.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class MenuItem : BaseMenuItem
+    public partial class MenuItem : BaseMenuItem
     {
         static MenuItem()
         {
@@ -21,8 +21,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public XF.ImageSource IconImageSource { get; set; }
         [Parameter] public bool? IsDestructive { get; set; }
         [Parameter] public string Text { get; set; }
-
-        [Parameter] public EventCallback OnClick { get; set; }
 
         public new XF.MenuItem NativeControl => ((MenuItemHandler)ElementHandler).MenuItemControl;
 
@@ -43,7 +41,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(Text), Text);
             }
 
-            builder.AddAttribute("onclick", OnClick);
+            RenderAdditionalAttributes(builder);
         }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.Custom.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class NavigableElement : Element
+    {
+        public async Task PopModalAsync(bool animated = true)
+        {
+            await NativeControl.Navigation.PopModalAsync(animated).ConfigureAwait(true);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/NavigableElement.cs
@@ -9,7 +9,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class NavigableElement : Element
+    public partial class NavigableElement : Element
     {
         /// <summary>
         /// A comma-separated list of style classes that should be applied to this element.
@@ -26,11 +26,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             {
                 builder.AddAttribute(nameof(StyleClass), StyleClass);
             }
+
+            RenderAdditionalAttributes(builder);
         }
 
-        public async Task PopModalAsync(bool animated = true)
-        {
-            await NativeControl.Navigation.PopModalAsync(animated).ConfigureAwait(true);
-        }
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Page.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Page.Custom.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Page : VisualElement
+    {
+#pragma warning disable CA1721 // Property names should not match get methods
+        [Parameter] public RenderFragment ChildContent { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        protected override RenderFragment GetChildContent() => ChildContent;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Page.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Page : VisualElement
+    public partial class Page : VisualElement
     {
         static Page()
         {
@@ -18,10 +18,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public XF.ImageSource IconImageSource { get; set; }
         [Parameter] public string Title { get; set; }
-
-#pragma warning disable CA1721 // Property names should not match get methods
-        [Parameter] public RenderFragment ChildContent { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
 
         public new XF.Page NativeControl => ((PageHandler)ElementHandler).PageControl;
 
@@ -37,8 +33,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             {
                 builder.AddAttribute(nameof(Title), Title);
             }
+
+            RenderAdditionalAttributes(builder);
         }
 
-        protected override RenderFragment GetChildContent() => ChildContent;
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.Custom.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ScrollView : Layout
+    {
+#pragma warning disable CA1721 // Property names should not match get methods
+        [Parameter] public RenderFragment ChildContent { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        protected override RenderFragment GetChildContent() => ChildContent;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ScrollView.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class ScrollView : Layout
+    public partial class ScrollView : Layout
     {
         static ScrollView()
         {
@@ -16,9 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 renderer => new ScrollViewHandler(renderer, new XF.ScrollView()));
         }
 
-#pragma warning disable CA1721 // Property names should not match get methods
-        [Parameter] public RenderFragment ChildContent { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
         [Parameter] public XF.ScrollBarVisibility? HorizontalScrollBarVisibility { get; set; }
         [Parameter] public XF.ScrollOrientation? Orientation { get; set; }
         [Parameter] public XF.ScrollBarVisibility? VerticalScrollBarVisibility { get; set; }
@@ -41,8 +38,10 @@ namespace Microsoft.MobileBlazorBindings.Elements
             {
                 builder.AddAttribute(nameof(VerticalScrollBarVisibility), (int)VerticalScrollBarVisibility.Value);
             }
+
+            RenderAdditionalAttributes(builder);
         }
 
-        protected override RenderFragment GetChildContent() => ChildContent;
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Shell.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Shell.Custom.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using System;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Shell : Page
+    {
+        [Parameter] public EventCallback<XF.ShellNavigatedEventArgs> OnNavigated { get; set; }
+        [Parameter] public EventCallback<XF.ShellNavigatingEventArgs> OnNavigating { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onnavigated", OnNavigated);
+            builder.AddAttribute("onnavigating", OnNavigating);
+        }
+
+        public async Task GoTo(XF.ShellNavigationState state, bool animate = true)
+        {
+            if (state is null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            await NativeControl.GoToAsync(state, animate).ConfigureAwait(true);
+        }
+
+#pragma warning disable CA1721 // Property names should not match get methods
+        protected override RenderFragment GetChildContent() => RenderChildContent;
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        private void RenderChildContent(RenderTreeBuilder builder)
+        {
+            if (FlyoutHeader != null)
+            {
+                builder.OpenComponent<ShellFlyoutHeader>(1);
+                builder.AddAttribute(0, nameof(ChildContent), FlyoutHeader);
+                builder.CloseComponent();
+            }
+
+            builder.AddContent(2, ChildContent);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Shell.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Shell.cs
@@ -11,7 +11,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Shell : Page
+    public partial class Shell : Page
     {
         static Shell()
         {
@@ -33,9 +33,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         //[Parameter] public IList<ShellItem> Items { get; } // TODO: Not needed? This is the Children collection
         //[Parameter] public DataTemplate ItemTemplate { get; set; }
         //[Parameter] public DataTemplate MenuItemTemplate { get; set; }
-
-        [Parameter] public EventCallback<XF.ShellNavigatedEventArgs> OnNavigated { get; set; }
-        [Parameter] public EventCallback<XF.ShellNavigatingEventArgs> OnNavigating { get; set; }
 
         public new XF.Shell NativeControl => ((ShellHandler)ElementHandler).ShellControl;
 
@@ -75,34 +72,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
             //[Parameter] public DataTemplate ItemTemplate { get; set; }
             //[Parameter] public DataTemplate MenuItemTemplate { get; set; }
 
-            builder.AddAttribute("onnavigated", OnNavigated);
-            builder.AddAttribute("onnavigating", OnNavigating);
+            RenderAdditionalAttributes(builder);
         }
 
-        public async Task GoTo(XF.ShellNavigationState state, bool animate = true)
-        {
-            if (state is null)
-            {
-                throw new ArgumentNullException(nameof(state));
-            }
-
-            await NativeControl.GoToAsync(state, animate).ConfigureAwait(true);
-        }
-
-#pragma warning disable CA1721 // Property names should not match get methods
-        protected override RenderFragment GetChildContent() => RenderChildContent;
-#pragma warning restore CA1721 // Property names should not match get methods
-
-        private void RenderChildContent(RenderTreeBuilder builder)
-        {
-            if (FlyoutHeader != null)
-            {
-                builder.OpenComponent<ShellFlyoutHeader>(1);
-                builder.AddAttribute(0, nameof(ChildContent), FlyoutHeader);
-                builder.CloseComponent();
-            }
-
-            builder.AddContent(2, ChildContent);
-        }
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.Custom.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ShellContent : BaseShellItem
+    {
+#pragma warning disable CA1721 // Property names should not match get methods
+        [Parameter] public RenderFragment ChildContent { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        protected override RenderFragment GetChildContent() => ChildContent;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellContent.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class ShellContent : BaseShellItem
+    public partial class ShellContent : BaseShellItem
     {
         static ShellContent()
         {
@@ -16,12 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 renderer => new ShellContentHandler(renderer, new XF.ShellContent()));
         }
 
-#pragma warning disable CA1721 // Property names should not match get methods
-        [Parameter] public RenderFragment ChildContent { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
-
         public new XF.ShellContent NativeControl => ((ShellContentHandler)ElementHandler).ShellContentControl;
-
-        protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.Custom.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ShellItem : ShellGroupItem
+    {
+#pragma warning disable CA1721 // Property names should not match get methods
+        [Parameter] public RenderFragment ChildContent { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        protected override RenderFragment GetChildContent() => ChildContent;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellItem.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class ShellItem : ShellGroupItem
+    public partial class ShellItem : ShellGroupItem
     {
         static ShellItem()
         {
@@ -16,12 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 renderer => new ShellItemHandler(renderer, new XF.ShellItem()));
         }
 
-#pragma warning disable CA1721 // Property names should not match get methods
-        [Parameter] public RenderFragment ChildContent { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
-
         public new XF.ShellItem NativeControl => ((ShellItemHandler)ElementHandler).ShellItemControl;
-
-        protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.Custom.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ShellSection : ShellGroupItem
+    {
+#pragma warning disable CA1721 // Property names should not match get methods
+        [Parameter] public RenderFragment ChildContent { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        protected override RenderFragment GetChildContent() => ChildContent;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellSection.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class ShellSection : ShellGroupItem
+    public partial class ShellSection : ShellGroupItem
     {
         static ShellSection()
         {
@@ -16,12 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 renderer => new ShellSectionHandler(renderer, new XF.ShellSection()));
         }
 
-#pragma warning disable CA1721 // Property names should not match get methods
-        [Parameter] public RenderFragment ChildContent { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
-
         public new XF.ShellSection NativeControl => ((ShellSectionHandler)ElementHandler).ShellSectionControl;
-
-        protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.Custom.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class StackLayout : Layout
+    {
+#pragma warning disable CA1721 // Property names should not match get methods
+        [Parameter] public RenderFragment ChildContent { get; set; }
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        protected override RenderFragment GetChildContent() => ChildContent;
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/StackLayout.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class StackLayout : Layout
+    public partial class StackLayout : Layout
     {
         static StackLayout()
         {
@@ -16,9 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 .RegisterElementHandler<StackLayout>(renderer => new StackLayoutHandler(renderer, new XF.StackLayout()));
         }
 
-#pragma warning disable CA1721 // Property names should not match get methods
-        [Parameter] public RenderFragment ChildContent { get; set; }
-#pragma warning restore CA1721 // Property names should not match get methods
         [Parameter] public XF.StackOrientation? Orientation { get; set; }
         [Parameter] public double? Spacing { get; set; }
 
@@ -37,7 +34,5 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(Spacing), AttributeHelper.DoubleToString(Spacing.Value));
             }
         }
-
-        protected override RenderFragment GetChildContent() => ChildContent;
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Stepper.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Stepper.Custom.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Stepper : View
+    {
+        [Parameter] public EventCallback<double> ValueChanged { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onvaluechanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleValueChanged));
+        }
+
+        private Task HandleValueChanged(ChangeEventArgs evt)
+        {
+            return ValueChanged.InvokeAsync((double)evt.Value);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Stepper.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Stepper.cs
@@ -9,7 +9,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Stepper : View
+    public partial class Stepper : View
     {
         static Stepper()
         {
@@ -21,8 +21,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public double? Maximum { get; set; }
         [Parameter] public double? Minimum { get; set; }
         [Parameter] public double? Value { get; set; }
-
-        [Parameter] public EventCallback<double> ValueChanged { get; set; }
 
         public new XF.Stepper NativeControl => ((StepperHandler)ElementHandler).StepperControl;
         
@@ -47,12 +45,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(Value), AttributeHelper.DoubleToString(Value.Value));
             }
 
-            builder.AddAttribute("onvaluechanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleValueChanged));
+            RenderAdditionalAttributes(builder);
         }
 
-        private Task HandleValueChanged(ChangeEventArgs evt)
-        {
-            return ValueChanged.InvokeAsync((double)evt.Value);
-        }
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Switch.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Switch.Custom.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Switch : View
+    {
+        [Parameter] public EventCallback<bool> IsToggledChanged { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onistoggledchanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleIsToggledChanged));
+        }
+
+        private Task HandleIsToggledChanged(ChangeEventArgs evt)
+        {
+            return IsToggledChanged.InvokeAsync((bool)evt.Value);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Switch.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Switch.cs
@@ -9,7 +9,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class Switch : View
+    public partial class Switch : View
     {
         static Switch()
         {
@@ -18,8 +18,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         }
 
         [Parameter] public bool? IsToggled { get; set; }
-
-        [Parameter] public EventCallback<bool> IsToggledChanged { get; set; }
 
         public new XF.Switch NativeControl => ((SwitchHandler)ElementHandler).SwitchControl;
 
@@ -32,13 +30,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(IsToggled), IsToggled.Value);
             }
 
-            builder.AddAttribute("onistoggledchanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleIsToggledChanged));
+            RenderAdditionalAttributes(builder);
         }
 
-        private Task HandleIsToggledChanged(ChangeEventArgs evt)
-        {
-            return IsToggledChanged.InvokeAsync((bool)evt.Value);
-        }
-
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.Custom.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.Custom.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class VisualElement : NavigableElement
+    {
+        [Parameter] public EventCallback<XF.FocusEventArgs> OnFocused { get; set; }
+        [Parameter] public EventCallback OnSizeChanged { get; set; }
+        [Parameter] public EventCallback<XF.FocusEventArgs> OnUnfocused { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onfocused", OnFocused);
+            builder.AddAttribute("onsizechanged", OnSizeChanged);
+            builder.AddAttribute("onunfocused", OnUnfocused);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/VisualElement.cs
@@ -8,7 +8,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements
 {
-    public class VisualElement : NavigableElement
+    public partial class VisualElement : NavigableElement
     {
         [Parameter] public double? AnchorX { get; set; }
         [Parameter] public double? AnchorY { get; set; }
@@ -32,10 +32,6 @@ namespace Microsoft.MobileBlazorBindings.Elements
         [Parameter] public double? TranslationX { get; set; }
         [Parameter] public double? TranslationY { get; set; }
         [Parameter] public double? WidthRequest { get; set; }
-
-        [Parameter] public EventCallback<XF.FocusEventArgs> OnFocused { get; set; }
-        [Parameter] public EventCallback OnSizeChanged { get; set; }
-        [Parameter] public EventCallback<XF.FocusEventArgs> OnUnfocused { get; set; }
 
         public new XF.VisualElement NativeControl => ((VisualElementHandler)ElementHandler).VisualElementControl;
 
@@ -132,9 +128,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
                 builder.AddAttribute(nameof(WidthRequest), AttributeHelper.DoubleToString(WidthRequest.Value));
             }
 
-            builder.AddAttribute("onfocused", OnFocused);
-            builder.AddAttribute("onsizechanged", OnSizeChanged);
-            builder.AddAttribute("onunfocused", OnUnfocused);
+            RenderAdditionalAttributes(builder);
         }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
     }
 }


### PR DESCRIPTION
To make the transition to generated code easier:
- All class customizations will go in one file (e.g. inner content, custom behavior)
- All stuff that will eventually be generated will go into another file

This change makes heavy use of partial classes and partial methods so that the generated and custom code can talk to each other.