### PR TITLE
New controls: BoxView, CheckBox, ImageButton, and Slider

### DIFF
--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -3,6 +3,7 @@ BaseMenuItem
 BaseShellItem
 BoxView
 Button
+CheckBox
 #ColumnDefinition // Not based on real XF type
 ContentPage
 ContentView

--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -1,6 +1,7 @@
 ActivityIndicator
 BaseMenuItem
 BaseShellItem
+BoxView
 Button
 #ColumnDefinition // Not based on real XF type
 ContentPage

--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -36,6 +36,7 @@ ShellContent
 ShellGroupItem
 ShellItem
 ShellSection
+Slider
 Span
 StackLayout
 Stepper

--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -16,6 +16,7 @@ GestureElement
 #Grid // Temporary because we need a way to handle special Grid.Metadata property
 #GridCell // Not based on real XF type
 Image
+ImageButton
 InputView
 Label
 Layout

--- a/src/Microsoft.MobileBlazorBindings/Elements/BoxView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/BoxView.generated.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class BoxView : View
+    {
+        static BoxView()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<BoxView>(
+                renderer => new BoxViewHandler(renderer, new XF.BoxView()));
+        }
+
+        [Parameter] public XF.Color? Color { get; set; }
+        [Parameter] public XF.CornerRadius? CornerRadius { get; set; }
+
+        public new XF.BoxView NativeControl => ((BoxViewHandler)ElementHandler).BoxViewControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (Color != null)
+            {
+                builder.AddAttribute(nameof(Color), AttributeHelper.ColorToString(Color.Value));
+            }
+            if (CornerRadius != null)
+            {
+                builder.AddAttribute(nameof(CornerRadius), AttributeHelper.CornerRadiusToString(CornerRadius.Value));
+            }
+
+            RenderAdditionalAttributes(builder);
+        }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Button.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Button.cs
@@ -9,10 +9,14 @@ namespace Microsoft.MobileBlazorBindings.Elements
     public partial class Button : View
     {
         [Parameter] public EventCallback OnClick { get; set; }
+        [Parameter] public EventCallback OnPress { get; set; }
+        [Parameter] public EventCallback OnRelease { get; set; }
 
         partial void RenderAdditionalAttributes(AttributesBuilder builder)
         {
             builder.AddAttribute("onclick", OnClick);
+            builder.AddAttribute("onpress", OnPress);
+            builder.AddAttribute("onrelease", OnRelease);
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using System.Threading.Tasks;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class CheckBox : View
+    {
+        [Parameter] public EventCallback<bool> IsCheckedChanged { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onischeckedchanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleIsCheckedChanged));
+        }
+
+        private Task HandleIsCheckedChanged(ChangeEventArgs evt)
+        {
+            return IsCheckedChanged.InvokeAsync((bool)evt.Value);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/CheckBox.generated.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class CheckBox : View
+    {
+        static CheckBox()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<CheckBox>(
+                renderer => new CheckBoxHandler(renderer, new XF.CheckBox()));
+        }
+
+        [Parameter] public XF.Color? Color { get; set; }
+        [Parameter] public bool? IsChecked { get; set; }
+
+        public new XF.CheckBox NativeControl => ((CheckBoxHandler)ElementHandler).CheckBoxControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (Color != null)
+            {
+                builder.AddAttribute(nameof(Color), AttributeHelper.ColorToString(Color.Value));
+            }
+            if (IsChecked != null)
+            {
+                builder.AddAttribute(nameof(IsChecked), IsChecked.Value);
+            }
+
+            RenderAdditionalAttributes(builder);
+        }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BoxViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BoxViewHandler.generated.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class BoxViewHandler : ViewHandler
+    {
+        public BoxViewHandler(NativeComponentRenderer renderer, XF.BoxView boxViewControl) : base(renderer, boxViewControl)
+        {
+            BoxViewControl = boxViewControl ?? throw new ArgumentNullException(nameof(boxViewControl));
+
+            Initialize(renderer);
+        }
+
+        partial void Initialize(NativeComponentRenderer renderer);
+
+        public XF.BoxView BoxViewControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.BoxView.Color):
+                    BoxViewControl.Color = AttributeHelper.StringToColor((string)attributeValue);
+                    break;
+                case nameof(XF.BoxView.CornerRadius):
+                    BoxViewControl.CornerRadius = AttributeHelper.StringToCornerRadius(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.cs
@@ -20,8 +20,34 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                     renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ClickEventHandlerId, null, e));
                 }
             };
+
+            RegisterEvent(
+                eventName: "onpress",
+                setId: id => PressEventHandlerId = id,
+                clearId: () => PressEventHandlerId = 0);
+            ButtonControl.Pressed += (s, e) =>
+            {
+                if (PressEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(PressEventHandlerId, null, e));
+                }
+            };
+
+            RegisterEvent(
+                eventName: "onrelease",
+                setId: id => ReleaseEventHandlerId = id,
+                clearId: () => ReleaseEventHandlerId = 0);
+            ButtonControl.Released += (s, e) =>
+            {
+                if (ReleaseEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ReleaseEventHandlerId, null, e));
+                }
+            };
         }
 
         public ulong ClickEventHandlerId { get; set; }
+        public ulong PressEventHandlerId { get; set; }
+        public ulong ReleaseEventHandlerId { get; set; }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class CheckBoxHandler : ViewHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            RegisterEvent(
+                eventName: "onischeckedchanged",
+                setId: id => IsCheckedChangedEventHandlerId = id,
+                clearId: () => IsCheckedChangedEventHandlerId = 0);
+            CheckBoxControl.CheckedChanged += (s, e) =>
+            {
+                if (IsCheckedChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(IsCheckedChangedEventHandlerId, null, new ChangeEventArgs { Value = e.Value }));
+                }
+            };
+        }
+
+        public ulong IsCheckedChangedEventHandlerId { get; set; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.generated.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class CheckBoxHandler : ViewHandler
+    {
+        public CheckBoxHandler(NativeComponentRenderer renderer, XF.CheckBox checkBoxControl) : base(renderer, checkBoxControl)
+        {
+            CheckBoxControl = checkBoxControl ?? throw new ArgumentNullException(nameof(checkBoxControl));
+
+            Initialize(renderer);
+        }
+
+        partial void Initialize(NativeComponentRenderer renderer);
+
+        public XF.CheckBox CheckBoxControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.CheckBox.Color):
+                    CheckBoxControl.Color = AttributeHelper.StringToColor((string)attributeValue);
+                    break;
+                case nameof(XF.CheckBox.IsChecked):
+                    CheckBoxControl.IsChecked = AttributeHelper.GetBool(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class ImageButtonHandler : ViewHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            RegisterEvent(
+                eventName: "onclick",
+                setId: id => ClickEventHandlerId = id,
+                clearId: () => ClickEventHandlerId = 0);
+            ImageButtonControl.Clicked += (s, e) =>
+            {
+                if (ClickEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ClickEventHandlerId, null, e));
+                }
+            };
+
+            RegisterEvent(
+                eventName: "onpress",
+                setId: id => PressEventHandlerId = id,
+                clearId: () => PressEventHandlerId = 0);
+            ImageButtonControl.Pressed += (s, e) =>
+            {
+                if (PressEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(PressEventHandlerId, null, e));
+                }
+            };
+
+            RegisterEvent(
+                eventName: "onrelease",
+                setId: id => ReleaseEventHandlerId = id,
+                clearId: () => ReleaseEventHandlerId = 0);
+            ImageButtonControl.Released += (s, e) =>
+            {
+                if (ReleaseEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ReleaseEventHandlerId, null, e));
+                }
+            };
+        }
+
+        public ulong ClickEventHandlerId { get; set; }
+        public ulong PressEventHandlerId { get; set; }
+        public ulong ReleaseEventHandlerId { get; set; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.generated.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class ImageButtonHandler : ViewHandler
+    {
+        public ImageButtonHandler(NativeComponentRenderer renderer, XF.ImageButton imageButtonControl) : base(renderer, imageButtonControl)
+        {
+            ImageButtonControl = imageButtonControl ?? throw new ArgumentNullException(nameof(imageButtonControl));
+
+            Initialize(renderer);
+        }
+
+        partial void Initialize(NativeComponentRenderer renderer);
+
+        public XF.ImageButton ImageButtonControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.ImageButton.Aspect):
+                    ImageButtonControl.Aspect = (XF.Aspect)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XF.ImageButton.BorderColor):
+                    ImageButtonControl.BorderColor = AttributeHelper.StringToColor((string)attributeValue);
+                    break;
+                case nameof(XF.ImageButton.BorderWidth):
+                    ImageButtonControl.BorderWidth = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    break;
+                case nameof(XF.ImageButton.CornerRadius):
+                    ImageButtonControl.CornerRadius = AttributeHelper.GetInt(attributeValue, -1);
+                    break;
+                case nameof(XF.ImageButton.IsOpaque):
+                    ImageButtonControl.IsOpaque = AttributeHelper.GetBool(attributeValue);
+                    break;
+                case nameof(XF.ImageButton.Padding):
+                    ImageButtonControl.Padding = AttributeHelper.StringToThickness(attributeValue);
+                    break;
+                case nameof(XF.ImageButton.Source):
+                    ImageButtonControl.Source = AttributeHelper.StringToImageSource(attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class SliderHandler : ViewHandler
+    {
+        partial void Initialize(NativeComponentRenderer renderer)
+        {
+            RegisterEvent(
+                eventName: "ondragcompleted",
+                setId: id => DragCompletedEventHandlerId = id,
+                clearId: () => DragCompletedEventHandlerId = 0);
+            SliderControl.DragCompleted += (s, e) =>
+            {
+                if (DragCompletedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(DragCompletedEventHandlerId, null, e));
+                }
+            };
+
+            RegisterEvent(
+                eventName: "ondragstarted",
+                setId: id => DragStartedEventHandlerId = id,
+                clearId: () => DragStartedEventHandlerId = 0);
+            SliderControl.DragStarted += (s, e) =>
+            {
+                if (DragStartedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(DragStartedEventHandlerId, null, e));
+                }
+            };
+
+            RegisterEvent(
+                eventName: "onvaluechanged",
+                setId: id => ValueChangedEventHandlerId = id,
+                clearId: () => ValueChangedEventHandlerId = 0);
+            SliderControl.ValueChanged += (s, e) =>
+            {
+                if (ValueChangedEventHandlerId != default)
+                {
+                    renderer.Dispatcher.InvokeAsync(() => renderer.DispatchEventAsync(ValueChangedEventHandlerId, null, new ChangeEventArgs { Value = e.NewValue }));
+                }
+            };
+        }
+
+        public ulong DragCompletedEventHandlerId { get; set; }
+        public ulong DragStartedEventHandlerId { get; set; }
+        public ulong ValueChangedEventHandlerId { get; set; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.generated.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class SliderHandler : ViewHandler
+    {
+        public SliderHandler(NativeComponentRenderer renderer, XF.Slider sliderControl) : base(renderer, sliderControl)
+        {
+            SliderControl = sliderControl ?? throw new ArgumentNullException(nameof(sliderControl));
+
+            Initialize(renderer);
+        }
+
+        partial void Initialize(NativeComponentRenderer renderer);
+
+        public XF.Slider SliderControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XF.Slider.Maximum):
+                    SliderControl.Maximum = AttributeHelper.StringToDouble((string)attributeValue, 1.00);
+                    break;
+                case nameof(XF.Slider.MaximumTrackColor):
+                    SliderControl.MaximumTrackColor = AttributeHelper.StringToColor((string)attributeValue);
+                    break;
+                case nameof(XF.Slider.Minimum):
+                    SliderControl.Minimum = AttributeHelper.StringToDouble((string)attributeValue);
+                    break;
+                case nameof(XF.Slider.MinimumTrackColor):
+                    SliderControl.MinimumTrackColor = AttributeHelper.StringToColor((string)attributeValue);
+                    break;
+                case nameof(XF.Slider.ThumbColor):
+                    SliderControl.ThumbColor = AttributeHelper.StringToColor((string)attributeValue);
+                    break;
+                case nameof(XF.Slider.ThumbImageSource):
+                    SliderControl.ThumbImageSource = AttributeHelper.StringToImageSource(attributeValue);
+                    break;
+                case nameof(XF.Slider.Value):
+                    SliderControl.Value = AttributeHelper.StringToDouble((string)attributeValue);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ImageButton : View
+    {
+        [Parameter] public EventCallback OnClick { get; set; }
+        [Parameter] public EventCallback OnPress { get; set; }
+        [Parameter] public EventCallback OnRelease { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("onclick", OnClick);
+            builder.AddAttribute("onpress", OnPress);
+            builder.AddAttribute("onrelease", OnRelease);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ImageButton.generated.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class ImageButton : View
+    {
+        static ImageButton()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<ImageButton>(
+                renderer => new ImageButtonHandler(renderer, new XF.ImageButton()));
+        }
+
+        [Parameter] public XF.Aspect? Aspect { get; set; }
+        [Parameter] public XF.Color? BorderColor { get; set; }
+        [Parameter] public double? BorderWidth { get; set; }
+        [Parameter] public int? CornerRadius { get; set; }
+        [Parameter] public bool? IsOpaque { get; set; }
+        [Parameter] public XF.Thickness? Padding { get; set; }
+        [Parameter] public XF.ImageSource Source { get; set; }
+
+        public new XF.ImageButton NativeControl => ((ImageButtonHandler)ElementHandler).ImageButtonControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (Aspect != null)
+            {
+                builder.AddAttribute(nameof(Aspect), (int)Aspect.Value);
+            }
+            if (BorderColor != null)
+            {
+                builder.AddAttribute(nameof(BorderColor), AttributeHelper.ColorToString(BorderColor.Value));
+            }
+            if (BorderWidth != null)
+            {
+                builder.AddAttribute(nameof(BorderWidth), AttributeHelper.DoubleToString(BorderWidth.Value));
+            }
+            if (CornerRadius != null)
+            {
+                builder.AddAttribute(nameof(CornerRadius), CornerRadius.Value);
+            }
+            if (IsOpaque != null)
+            {
+                builder.AddAttribute(nameof(IsOpaque), IsOpaque.Value);
+            }
+            if (Padding != null)
+            {
+                builder.AddAttribute(nameof(Padding), AttributeHelper.ThicknessToString(Padding.Value));
+            }
+            if (Source != null)
+            {
+                builder.AddAttribute(nameof(Source), AttributeHelper.ImageSourceToString(Source));
+            }
+
+            RenderAdditionalAttributes(builder);
+        }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Slider.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Slider.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using System.Threading.Tasks;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Slider : View
+    {
+        [Parameter] public EventCallback OnDragCompleted { get; set; }
+        [Parameter] public EventCallback OnDragStarted { get; set; }
+        [Parameter] public EventCallback<double> ValueChanged { get; set; }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder)
+        {
+            builder.AddAttribute("ondragcompleted", OnDragCompleted);
+            builder.AddAttribute("ondragstarted", OnDragStarted);
+            builder.AddAttribute("onvaluechanged", EventCallback.Factory.Create<ChangeEventArgs>(this, HandleValueChanged));
+        }
+
+        private Task HandleValueChanged(ChangeEventArgs evt)
+        {
+            return ValueChanged.InvokeAsync((double)evt.Value);
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Slider.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Slider.generated.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class Slider : View
+    {
+        static Slider()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<Slider>(
+                renderer => new SliderHandler(renderer, new XF.Slider()));
+        }
+
+        [Parameter] public double? Maximum { get; set; }
+        [Parameter] public XF.Color? MaximumTrackColor { get; set; }
+        [Parameter] public double? Minimum { get; set; }
+        [Parameter] public XF.Color? MinimumTrackColor { get; set; }
+        [Parameter] public XF.Color? ThumbColor { get; set; }
+        [Parameter] public XF.ImageSource ThumbImageSource { get; set; }
+        [Parameter] public double? Value { get; set; }
+
+        public new XF.Slider NativeControl => ((SliderHandler)ElementHandler).SliderControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (Maximum != null)
+            {
+                builder.AddAttribute(nameof(Maximum), AttributeHelper.DoubleToString(Maximum.Value));
+            }
+            if (MaximumTrackColor != null)
+            {
+                builder.AddAttribute(nameof(MaximumTrackColor), AttributeHelper.ColorToString(MaximumTrackColor.Value));
+            }
+            if (Minimum != null)
+            {
+                builder.AddAttribute(nameof(Minimum), AttributeHelper.DoubleToString(Minimum.Value));
+            }
+            if (MinimumTrackColor != null)
+            {
+                builder.AddAttribute(nameof(MinimumTrackColor), AttributeHelper.ColorToString(MinimumTrackColor.Value));
+            }
+            if (ThumbColor != null)
+            {
+                builder.AddAttribute(nameof(ThumbColor), AttributeHelper.ColorToString(ThumbColor.Value));
+            }
+            if (ThumbImageSource != null)
+            {
+                builder.AddAttribute(nameof(ThumbImageSource), AttributeHelper.ImageSourceToString(ThumbImageSource));
+            }
+            if (Value != null)
+            {
+                builder.AddAttribute(nameof(Value), AttributeHelper.DoubleToString(Value.Value));
+            }
+
+            RenderAdditionalAttributes(builder);
+        }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
+    }
+}


### PR DESCRIPTION
New components available in Experimental Mobile Blazor Bindings!

Here's an example of using `<Slider>` with a two-way binding:

```xml
@code
{ 
    double mySlider = 6f;
}

<StackLayout>
    <Slider @bind-Value="mySlider" HorizontalOptions="LayoutOptions.Fill" Minimum="5.3" Maximum="10.8" />
    <Label Text="@("Current value is " + mySlider)" />
</StackLayout>
```

And `<ImageButton>`:

```xml
<ImageButton Source="@(new FileImageSource{File = "button.png"})" OnClick="MyOnClick" CornerRadius="4" />
```
