### PR TITLE
Fix iOS default template experience

### DIFF
--- a/templates/MobileBlazorBindings-app/NewApp/App.cs
+++ b/templates/MobileBlazorBindings-app/NewApp/App.cs
@@ -18,7 +18,8 @@ namespace NewApp
                 })
                 .Build();
 
-            host.AddComponent<HelloWorld>(parent: this);
+            MainPage = new ContentPage();
+            host.AddComponent<HelloWorld>(parent: MainPage);
         }
 
         protected override void OnStart()

--- a/templates/MobileBlazorBindings-app/NewApp/HelloWorld.razor
+++ b/templates/MobileBlazorBindings-app/NewApp/HelloWorld.razor
@@ -1,4 +1,4 @@
-﻿<ContentPage>
+﻿<ContentView>
     <StackLayout Margin="new Thickness(20)">
 
         <Label Text="Hello, World!"
@@ -7,4 +7,4 @@
         <Counter />
 
     </StackLayout>
-</ContentPage>
+</ContentView>


### PR DESCRIPTION
Xamarin.Forms on iOS seems to not like having an async MainPage load. So the default template now has an initial empty MainPage, which is a ContentPage, and the main app page in Blazor is now a ContentView (instead of a ContentPage) that is set as the content of that MainPage.

Fixes #30 