### PR TITLE
Added a fix for the fact that the AssemblyName can and will be null

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.WebView.JS/src/Boot.Desktop.ts
+++ b/src/Microsoft.MobileBlazorBindings.WebView.JS/src/Boot.Desktop.ts
@@ -8,9 +8,9 @@ import { decode } from 'base64-arraybuffer';
 import * as ipc from './IPC';
 
 function boot() {
-  setEventDispatcher((eventDescriptor, eventArgs) => DotNet.invokeMethodAsync('WebWindow.Blazor', 'DispatchEvent', eventDescriptor, JSON.stringify(eventArgs)));
+  setEventDispatcher((eventDescriptor, eventArgs) => DotNet.invokeMethodAsync('Microsoft.MobileBlazorBindings.WebView', 'DispatchEvent', eventDescriptor, JSON.stringify(eventArgs)));
   navigationManagerFunctions.listenForNavigationEvents((uri: string, intercepted: boolean) => {
-    return DotNet.invokeMethodAsync('WebWindow.Blazor', 'NotifyLocationChanged', uri, intercepted);
+    return DotNet.invokeMethodAsync('Microsoft.MobileBlazorBindings.WebView', 'NotifyLocationChanged', uri, intercepted);
   });
 
   // Configure the mechanism for JS<->NET calls

--- a/src/Microsoft.MobileBlazorBindings.WebView/Elements/BlazorWebView.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView/Elements/BlazorWebView.cs
@@ -208,7 +208,7 @@ namespace Microsoft.MobileBlazorBindings.WebView.Elements
             _ipc.On("BeginInvokeDotNetFromJS", args =>
             {
                 var argsArray = (object[])args;
-                var assemblyName = ((JsonElement)argsArray[1]).GetString();
+                var assemblyName = argsArray[1] != null ? ((JsonElement)argsArray[1]).GetString() : null;
                 var methodIdentifier = ((JsonElement)argsArray[2]).GetString();
                 var dotNetObjectId = ((JsonElement)argsArray[3]).GetInt64();
                 var callId = ((JsonElement)argsArray[0]).GetString();
@@ -218,7 +218,7 @@ namespace Microsoft.MobileBlazorBindings.WebView.Elements
                 // and direct them to our own instance. This is to avoid needing a static BlazorHybridRenderer.Instance.
                 // Similar temporary hack for navigation notifications
                 // TODO: Change blazor.desktop.js to use a dedicated IPC call for these calls, not JS interop.
-                if (assemblyName == "WebWindow.Blazor")
+                if (assemblyName == "Microsoft.MobileBlazorBindings.WebView")
                 {
                     assemblyName = null;
                     dotNetObjectId = selfAsDotnetObjectReferenceId;


### PR DESCRIPTION
- Added a fix for the fact that the AssemblyName can and will be null when an invocation happens on an object reference instead of a static method.
- Changed the assembly name for the DispatchEvent and LocationChanged interop calls to match the actual assemblyname.