### PR TITLE
ElementReferences do not work.

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.WebView/BlazorHybridJSRuntime.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView/BlazorHybridJSRuntime.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 using System;
@@ -17,6 +18,7 @@ namespace Microsoft.MobileBlazorBindings.WebView
         public BlazorHybridJSRuntime(IPC ipc)
         {
             _ipc = ipc ?? throw new ArgumentNullException(nameof(ipc));
+            JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter());
         }
 
         protected override void BeginInvokeJS(long asyncHandle, string identifier, string argsJson)

--- a/src/Microsoft.MobileBlazorBindings.WebView/SharedSource/ElementReferenceJsonConverter.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView/SharedSource/ElementReferenceJsonConverter.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.AspNetCore.Components
+{
+    internal sealed class ElementReferenceJsonConverter : JsonConverter<ElementReference>
+    {
+        private static readonly JsonEncodedText IdProperty = JsonEncodedText.Encode("__internalId");
+
+        public override ElementReference Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            string id = null;
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(IdProperty.EncodedUtf8Bytes))
+                    {
+                        reader.Read();
+                        id = reader.GetString();
+                    }
+                    else
+                    {
+                        throw new JsonException($"Unexpected JSON property '{reader.GetString()}'.");
+                    }
+                }
+                else
+                {
+                    throw new JsonException($"Unexpected JSON Token {reader.TokenType}.");
+                }
+            }
+
+            if (id is null)
+            {
+                throw new JsonException("__internalId is required.");
+            }
+
+            return new ElementReference(id);
+        }
+
+        public override void Write(Utf8JsonWriter writer, ElementReference value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString(IdProperty, value.Id);
+            writer.WriteEndObject();
+        }
+    }
+}


### PR DESCRIPTION
ElementReferences do not work because the ElementReferenceJsonConverter is missing.
see https://github.com/SteveSandersonMS/WebWindow/issues/97

Fixed by copying ElementReferenceJsonConverter over from aspnetcore and adding it to the list of converters used by the JSRuntime.