### PR TITLE
Fixed Error when using CSS on iOS

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StyleSheetHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StyleSheetHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                     {
                         throw new InvalidOperationException($"Specifying a '{nameof(Resource)}' property value '{Resource}' requires also specifying the '{nameof(Assembly)}' property to indicate the assembly containing the resource.");
                     }
-                    var styleSheet = XFS.StyleSheet.FromResource(resourcePath: Resource, assembly: Assembly);
+                    var styleSheet = XFS.StyleSheet.FromAssemblyResource(Assembly, $"{Assembly.GetName().Name}.{Resource}");
                     _parentVisualElement.Resources.Add(styleSheet);
                 }
                 if (Text != null)


### PR DESCRIPTION
Hi there,
This PR fixes #140, but it requires using a Xamarin Forms method that is marked obsolete so I'm not sure if this is a good answer. 

I updated StyleSheetHandler to use a diferent Xamarin Forms method for loading the CSS File.

When it was using FromResource we would get a NullReferenceException when Forms tries to find an IResourceLoader.

This fix uses FromAssemblyResource() Line 23 instead of FromResource() Line 35 in https://github.com/xamarin/Xamarin.Forms/blob/main/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs . Perhaps the real fix needs to happen in the Forms repo.