### PR TITLE
Added placeholder page on launch and update ElementManager to allow r…

### DIFF
--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/App.cs
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/App.cs
@@ -21,6 +21,10 @@ namespace MobileBlazorBindingsXaminals
                 })
                 .Build();
 
+            //We have to set a placeholder MainPage here, because setting it in AddComponent happens after it returns.
+            //This causes iOS to kill the app because iOS thinks we never set a page.
+            MainPage = new ContentPage();
+            
             AppHost.AddComponent<AppShell>(parent: this);
         }
 

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
@@ -31,20 +31,14 @@ namespace Microsoft.MobileBlazorBindings
 
             if (parentHandler.ElementControl is Application parentAsApp)
             {
-                if (parentAsApp.MainPage != null)
+                if (childHandler.ElementControl is Page childControlAsPage)
                 {
-                    throw new InvalidOperationException($"Application already has MainPage set; cannot set {parentAsApp.GetType().FullName}'s MainPage to {childHandler.ElementControl.GetType().FullName}");
+                    //MainPage may already be set, but it is safe to replace it.
+                    parentAsApp.MainPage = childControlAsPage;
                 }
                 else
                 {
-                    if (childHandler.ElementControl is Page childControlAsPage)
-                    {
-                        parentAsApp.MainPage = childControlAsPage;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException($"Application MainPage must be a Page; cannot set {parentAsApp.GetType().FullName}'s MainPage to {childHandler.ElementControl.GetType().FullName}");
-                    }
+                    throw new InvalidOperationException($"Application MainPage must be a Page; cannot set {parentAsApp.GetType().FullName}'s MainPage to {childHandler.ElementControl.GetType().FullName}");
                 }
                 return;
             }


### PR DESCRIPTION
…eplacing MainPage

This fixes issue #138, but is a bit of a workaround rather than a proper fix, but adding this now doesn't cause any real harm or prevent more work on it later.

I've put more details about why I couldn't fix the async call in the issue comments.

# Changes
Added a placeholder page in the App constructor so that there is a root view strain away.

Updated MobileBlazorBindingsElementManager to allow MainPages being swapped at run time, there was previously a check to make sure MainPage wasn't already set, which I don't think is necessary.

Changes in MobileBlazorBindingsElementManager  look a lot more complex than they are because indentation changed when I remove the if check.