### PR TITLE
DPI Fixes.

### DIFF
--- a/samples/HybridApp/HybridApp.Windows/HybridApp.Windows.csproj
+++ b/samples/HybridApp/HybridApp.Windows/HybridApp.Windows.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/HybridApp/HybridApp.Windows/app.manifest
+++ b/samples/HybridApp/HybridApp.Windows/app.manifest
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        PerMonitorV2
+      </dpiAwareness>
+    </windowsSettings>
+  </application>
+  
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/samples/HybridMessageApp/HybridMessageApp.Windows/HybridMessageApp.Windows.csproj
+++ b/samples/HybridMessageApp/HybridMessageApp.Windows/HybridMessageApp.Windows.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWPF>true</UseWPF>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/HybridMessageApp/HybridMessageApp.Windows/app.manifest
+++ b/samples/HybridMessageApp/HybridMessageApp.Windows/app.manifest
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        PerMonitorV2
+      </dpiAwareness>
+    </windowsSettings>
+  </application>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
@@ -6,6 +6,8 @@ using Microsoft.MobileBlazorBindings.WebView.Windows;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
 using System;
+using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
@@ -20,6 +22,8 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
 {
     public class WebViewExtendedAnaheimRenderer : ViewRenderer<WebViewExtended, WebView2>, XF.IWebViewDelegate
     {
+        private CoreWebView2Environment coreWebView2Environment = null;
+
         protected override void OnElementChanged(ElementChangedEventArgs<WebViewExtended> e)
         {
             if (e is null)
@@ -61,7 +65,10 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
                     var nativeControl = new WebView2() { MinHeight = 200 };
                     e.NewElement.RetainedNativeControl = nativeControl;
                     SetNativeControl(nativeControl);
-                    await nativeControl.EnsureCoreWebView2Async().ConfigureAwait(true);
+
+                    coreWebView2Environment = await CoreWebView2Environment.CreateAsync().ConfigureAwait(true);
+
+                    await nativeControl.EnsureCoreWebView2Async(coreWebView2Environment).ConfigureAwait(true);
 
                     await Control.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync("window.external = { sendMessage: function(message) { window.chrome.webview.postMessage(message); }, receiveMessage: function(callback) { window.chrome.webview.addEventListener(\'message\', function(e) { callback(e.data); }); } };").ConfigureAwait(true);
                     await Control.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(LoadBlazorJSScript).ConfigureAwait(true);
@@ -75,6 +82,11 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
             }
 
             base.OnElementChanged(e);
+
+            // There is a weird bug in WebView2 where on 200% DPI it does not redraw the WebView2 until you
+            // send a WM_WINDOWPOSCHANGING message to the child window that serves as a host for WebView2.
+            // this sends the required message.
+            Control.UpdateWindowPos();
         }
 
         private void SubscribeToElementEvents()
@@ -131,9 +143,8 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
                 {
                     responseStream.Position = 0;
 
-                    var environment = (CoreWebView2Environment)Control.GetType().GetProperty("Environment", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic).GetValue(Control);
-                    field = environment.GetType().GetField("_nativeCoreWebView2Environment", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                    var nativeEnvironment = field.GetValue(environment);
+                    field = coreWebView2Environment.GetType().GetField("_nativeCoreWebView2Environment", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    var nativeEnvironment = field.GetValue(coreWebView2Environment);
 
                     var managedStream = Activator.CreateInstance(eventType.Assembly.GetType("Microsoft.Web.WebView2.Core.ManagedIStream"),
                         System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,

--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
 {
     public class WebViewExtendedAnaheimRenderer : ViewRenderer<WebViewExtended, WebView2>, XF.IWebViewDelegate
     {
-        private CoreWebView2Environment coreWebView2Environment = null;
+        private CoreWebView2Environment _coreWebView2Environment = null;
 
         protected override void OnElementChanged(ElementChangedEventArgs<WebViewExtended> e)
         {
@@ -66,9 +66,9 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
                     e.NewElement.RetainedNativeControl = nativeControl;
                     SetNativeControl(nativeControl);
 
-                    coreWebView2Environment = await CoreWebView2Environment.CreateAsync().ConfigureAwait(true);
+                    _coreWebView2Environment = await CoreWebView2Environment.CreateAsync().ConfigureAwait(true);
 
-                    await nativeControl.EnsureCoreWebView2Async(coreWebView2Environment).ConfigureAwait(true);
+                    await nativeControl.EnsureCoreWebView2Async(_coreWebView2Environment).ConfigureAwait(true);
 
                     await Control.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync("window.external = { sendMessage: function(message) { window.chrome.webview.postMessage(message); }, receiveMessage: function(callback) { window.chrome.webview.addEventListener(\'message\', function(e) { callback(e.data); }); } };").ConfigureAwait(true);
                     await Control.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(LoadBlazorJSScript).ConfigureAwait(true);
@@ -143,8 +143,8 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
                 {
                     responseStream.Position = 0;
 
-                    field = coreWebView2Environment.GetType().GetField("_nativeCoreWebView2Environment", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                    var nativeEnvironment = field.GetValue(coreWebView2Environment);
+                    field = _coreWebView2Environment.GetType().GetField("_nativeCoreWebView2Environment", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    var nativeEnvironment = field.GetValue(_coreWebView2Environment);
 
                     var managedStream = Activator.CreateInstance(eventType.Assembly.GetType("Microsoft.Web.WebView2.Core.ManagedIStream"),
                         System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,

--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
 {
     public class WebViewExtendedAnaheimRenderer : ViewRenderer<WebViewExtended, WebView2>, XF.IWebViewDelegate
     {
-        private CoreWebView2Environment _coreWebView2Environment = null;
+        private CoreWebView2Environment _coreWebView2Environment;
 
         protected override void OnElementChanged(ElementChangedEventArgs<WebViewExtended> e)
         {


### PR DESCRIPTION
- Added proper DPI manifests that work on Windows 10 and Windows 7.
- Fixed a bug where the WPF control would render at 25% of the size at 200% DPI scaling. Fixes #137.
- Initialize the CoreWebView2Environment explicitly to eliminate some reflection.