### PR TITLE
Add experimental DualScreen support

### DIFF
--- a/MobileBlazorBindings.sln
+++ b/MobileBlazorBindings.sln
@@ -76,9 +76,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MobileBlazorBindi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MobileBlazorBindings.WebView.Android", "src\Microsoft.MobileBlazorBindings.WebView.Android\Microsoft.MobileBlazorBindings.WebView.Android.csproj", "{4041365C-EC53-4D91-9D23-EA86B4778FF0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.MobileBlazorBindings.WebView.iOS", "src\Microsoft.MobileBlazorBindings.WebView.iOS\Microsoft.MobileBlazorBindings.WebView.iOS.csproj", "{3CECADBB-3E56-4D47-A313-CE9E43DCAB02}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MobileBlazorBindings.WebView.iOS", "src\Microsoft.MobileBlazorBindings.WebView.iOS\Microsoft.MobileBlazorBindings.WebView.iOS.csproj", "{3CECADBB-3E56-4D47-A313-CE9E43DCAB02}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.MobileBlazorBindings.WebView.macOS", "src\Microsoft.MobileBlazorBindings.WebView.macOS\Microsoft.MobileBlazorBindings.WebView.macOS.csproj", "{5644B2A3-5B96-44D5-A244-4E7E450E2196}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MobileBlazorBindings.WebView.macOS", "src\Microsoft.MobileBlazorBindings.WebView.macOS\Microsoft.MobileBlazorBindings.WebView.macOS.csproj", "{5644B2A3-5B96-44D5-A244-4E7E450E2196}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MobileBlazorBindings.WebView.Windows", "src\Microsoft.MobileBlazorBindings.WebView.Windows\Microsoft.MobileBlazorBindings.WebView.Windows.csproj", "{69571F1B-D2C2-4152-A15D-F753397AFC16}"
 EndProject
@@ -103,6 +103,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HybridMessageApp.Windows", "samples\HybridMessageApp\HybridMessageApp.Windows\HybridMessageApp.Windows.csproj", "{E94D9E33-867F-4D47-8FC5-52E1B0783D1C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HybridMessageApp.Android", "samples\HybridMessageApp\HybridMessageApp.Android\HybridMessageApp.Android.csproj", "{96B3AB56-0FBC-4E73-ABBA-7AFB204E3E76}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MobileBlazorBindings.DualScreen", "src\Microsoft.MobileBlazorBindings.DualScreen\Microsoft.MobileBlazorBindings.DualScreen.csproj", "{CBE78113-CCF0-43DA-8461-787649DDB671}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -546,6 +548,18 @@ Global
 		{96B3AB56-0FBC-4E73-ABBA-7AFB204E3E76}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{96B3AB56-0FBC-4E73-ABBA-7AFB204E3E76}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{96B3AB56-0FBC-4E73-ABBA-7AFB204E3E76}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Release|iPhone.Build.0 = Release|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{CBE78113-CCF0-43DA-8461-787649DDB671}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -591,6 +605,7 @@ Global
 		{067B3562-A60A-48CB-A917-4B7D9700120A} = {A1CEA2C3-9558-4578-B22E-09109111BE1A}
 		{E94D9E33-867F-4D47-8FC5-52E1B0783D1C} = {A1CEA2C3-9558-4578-B22E-09109111BE1A}
 		{96B3AB56-0FBC-4E73-ABBA-7AFB204E3E76} = {A1CEA2C3-9558-4578-B22E-09109111BE1A}
+		{CBE78113-CCF0-43DA-8461-787649DDB671} = {175AB6E2-5FB5-4C15-94C2-DCA2EE6B0703}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A645A7FF-3F09-414D-A391-7E50C3597F05}

--- a/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.csproj
+++ b/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Microsoft.MobileBlazorBindings\Microsoft.MobileBlazorBindings.csproj" />
+    <!--
+      NOTE: This project doesn't currently use any DualScreen features, but this reference is here
+      to make it easier to try out DualScreen features.
+    -->
+    <ProjectReference Include="..\..\..\src\Microsoft.MobileBlazorBindings.DualScreen\Microsoft.MobileBlazorBindings.DualScreen.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ComponentWrapperGenerator/ComponentLocation.cs
+++ b/src/ComponentWrapperGenerator/ComponentLocation.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+
+namespace ComponentWrapperGenerator
+{
+    public class ComponentLocation
+    {
+        public Assembly Assembly { get; }
+        public string NamespaceName { get; }
+        public string NamespacePrefix { get; }
+        public string XmlDocFilename { get; }
+
+        public ComponentLocation(Assembly assembly, string namespaceName, string namespacePrefix, string xmlDocFilename)
+        {
+            Assembly = assembly;
+            NamespaceName = namespaceName;
+            NamespacePrefix = namespacePrefix;
+            XmlDocFilename = xmlDocFilename;
+        }
+    }
+}

--- a/src/ComponentWrapperGenerator/ComponentWrapperGenerator.csproj
+++ b/src/ComponentWrapperGenerator/ComponentWrapperGenerator.csproj
@@ -25,10 +25,19 @@
       <PrivateAssets></PrivateAssets>
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
+    <PackageReference Include="Xamarin.Forms.DualScreen" Version="4.6.0.800">
+      <IncludeAssets></IncludeAssets>
+      <PrivateAssets></PrivateAssets>
+      <GeneratePathProperty>true</GeneratePathProperty>
+    </PackageReference>
   </ItemGroup>
 
-  <Target Name="CopyXamarinFormsXmlDocToOutput" AfterTargets="Build">
+  <Target Name="CopyXmlDocsToOutput" AfterTargets="Build">
     <Message Text="Xamarin.Forms package location: $(PkgXamarin_Forms)" />
     <Copy SourceFiles="$(PkgXamarin_Forms)\lib\netstandard2.0\Xamarin.Forms.Core.xml" DestinationFolder="$(OutDir)" />
+    
+    <!-- Xamarin.Forms.DualScreen doesn't have any XML docs at this time -->
+    <!--<Message Text="Xamarin.Forms.DualScreen package location: $(PkgXamarin_Forms_DualScreen)" />
+    <Copy SourceFiles="$(PkgXamarin_Forms_DualScreen)\lib\netstandard2.0\Xamarin.Forms.DualScreen.xml" DestinationFolder="$(OutDir)" />-->
   </Target>
 </Project>

--- a/src/ComponentWrapperGenerator/Program.cs
+++ b/src/ComponentWrapperGenerator/Program.cs
@@ -2,31 +2,40 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
 
 namespace ComponentWrapperGenerator
 {
     internal class Program
     {
+        private static readonly List<ComponentLocation> ComponentLocations =
+            new List<ComponentLocation>
+            {
+                new ComponentLocation(typeof(Xamarin.Forms.Element).Assembly, "Xamarin.Forms", "XF", @"bin\Debug\netcoreapp3.0\Xamarin.Forms.Core.xml"),
+                new ComponentLocation(typeof(Xamarin.Forms.DualScreen.TwoPaneView).Assembly, "Xamarin.Forms.DualScreen", "XFD", null),
+            };
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "<Pending>")]
         internal static int Main(string[] args)
         {
             // Un-comment these lines for easier debugging
-            //if (args.Length == 0)
-            //{
-            //    args = new string[] { "TypesToGenerate.txt", ".", @"..\out" };
-            //}
-
-            if (args.Length != 3)
+            if (args.Length == 0)
             {
-                Console.WriteLine("Usage: dotnet run FileWithOneTypePerLine.txt XmlDocsFolder ..\\OutputFolder");
-                Console.WriteLine("    FileWithOneTypePerLine.txt must list types in the Xamarin.Forms namespace in the Xamarin.Forms assembly.");
+                args = new string[] { "TypesToGenerate.txt", @"..\out" };
+            }
+
+            if (args.Length != 2)
+            {
+                Console.WriteLine("Usage: dotnet run FileWithOneTypePerLine.txt ..\\OutputFolder");
+                Console.WriteLine("    FileWithOneTypePerLine.txt must list types in the Xamarin.Forms[.DualScreen] namespace in the Xamarin.Forms[.DualScreen] assembly.");
                 return -1;
             }
 
             var listOfTypeNamesToGenerate = File.ReadAllLines(args[0]);
-            var outputFolder = args[2];
+            var outputFolder = args[1];
 
             var settings = new GeneratorSettings
             {
@@ -36,10 +45,9 @@ namespace ComponentWrapperGenerator
                 RootNamespace = "Microsoft.MobileBlazorBindings.Elements",
             };
 
-            var generator = new ComponentWrapperGenerator(settings);
-            var xmlDocs = new XmlDocument();
-            var xmlDocPath = Path.Combine(Directory.GetCurrentDirectory(), args[1], "Xamarin.Forms.Core.xml");
-            xmlDocs.Load(xmlDocPath);
+            var xmlDocs = LoadXmlDocs(ComponentLocations.Select(loc => loc.XmlDocFilename).Where(loc => loc != null));
+
+            var generator = new ComponentWrapperGenerator(settings, xmlDocs, ComponentLocations);
 
             foreach (var typeNameToGenerate in listOfTypeNamesToGenerate)
             {
@@ -60,11 +68,32 @@ namespace ComponentWrapperGenerator
                     Console.WriteLine();
                     continue;
                 }
-                generator.GenerateComponentWrapper(typeToGenerate, xmlDocs, outputFolder);
+                generator.GenerateComponentWrapper(typeToGenerate, outputFolder);
                 Console.WriteLine();
             }
 
             return 0;
+        }
+
+        private static IList<XmlDocument> LoadXmlDocs(IEnumerable<string> xmlDocLocations)
+        {
+            var xmlDocs = new List<XmlDocument>();
+            foreach (var xmlDocLocation in xmlDocLocations)
+            {
+                var xmlDoc = new XmlDocument();
+
+                // Depending on whether you run from VS or command line, the relative path of the XML docs will be
+                // different. There's undoubtedly a better way to do this, but this works great.
+                var xmlDocPath = Path.Combine(Directory.GetCurrentDirectory(), xmlDocLocation);
+                if (!File.Exists(xmlDocPath))
+                {
+                    xmlDocPath = Path.Combine(Directory.GetCurrentDirectory(), Path.GetFileName(xmlDocLocation));
+                }
+
+                xmlDoc.Load(xmlDocPath);
+                xmlDocs.Add(xmlDoc);
+            }
+            return xmlDocs;
         }
 
         private static bool IsCommentLine(string typeNameToGenerate)
@@ -74,9 +103,18 @@ namespace ComponentWrapperGenerator
 
         private static bool TryGetTypeToGenerate(string typeName, out Type typeToGenerate)
         {
-            var fullTypeName = "Xamarin.Forms." + typeName;
-            typeToGenerate = typeof(Xamarin.Forms.Element).Assembly.GetType(fullTypeName);
-            return typeToGenerate != null;
+            foreach (var componentLocation in ComponentLocations)
+            {
+                var fullTypeName = componentLocation.NamespaceName + "." + typeName;
+                typeToGenerate = componentLocation.Assembly.GetType(fullTypeName);
+                if (typeToGenerate != null)
+                {
+                    return true;
+                }
+            }
+
+            typeToGenerate = null;
+            return false;
         }
     }
 }

--- a/src/ComponentWrapperGenerator/TypesToGenerate.txt
+++ b/src/ComponentWrapperGenerator/TypesToGenerate.txt
@@ -1,3 +1,4 @@
+# Xamarin.Forms components
 ActivityIndicator
 BaseMenuItem
 BaseShellItem
@@ -49,3 +50,6 @@ TemplatedPage
 TemplatedView
 View
 VisualElement
+
+# Xamarin.Forms.DualScreen components
+TwoPaneView

--- a/src/ComponentWrapperGenerator/UsingStatement.cs
+++ b/src/ComponentWrapperGenerator/UsingStatement.cs
@@ -7,6 +7,7 @@ namespace ComponentWrapperGenerator
     {
         public string Alias { get; set; }
         public string Namespace { get; set; }
+        public bool IsUsed { get; set; }
 
         public string ComparableString => Alias?.ToUpperInvariant() ?? Namespace?.ToUpperInvariant();
 

--- a/src/ComponentWrapperGenerator/generate.cmd
+++ b/src/ComponentWrapperGenerator/generate.cmd
@@ -1,1 +1,1 @@
-dotnet run TypesToGenerate.txt bin\Debug\netcoreapp3.0 ..\out
+dotnet run TypesToGenerate.txt ..\out

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/.editorconfig
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/.editorconfig
@@ -1,0 +1,7 @@
+﻿[*.cs]
+
+# BL0006: Do not use RenderTree types
+dotnet_diagnostic.BL0006.severity = none
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = none

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class TwoPaneViewHandler : GridHandler
+    {
+        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        {
+            if (child is null)
+            {
+                throw new ArgumentNullException(nameof(child));
+            }
+
+            if (child is TwoPaneViewPane1View pane1View)
+            {
+                TwoPaneViewControl.Pane1 = pane1View;
+            }
+            else if (child is TwoPaneViewPane2View pane2View)
+            {
+                TwoPaneViewControl.Pane2 = pane2View;
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unknown child type {child.GetType().FullName} being added to parent element type {GetType().FullName}.");
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.generated.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+using XFD = Xamarin.Forms.DualScreen;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public partial class TwoPaneViewHandler : GridHandler
+    {
+        public TwoPaneViewHandler(NativeComponentRenderer renderer, XFD.TwoPaneView twoPaneViewControl) : base(renderer, twoPaneViewControl)
+        {
+            TwoPaneViewControl = twoPaneViewControl ?? throw new ArgumentNullException(nameof(twoPaneViewControl));
+
+            Initialize(renderer);
+        }
+
+        partial void Initialize(NativeComponentRenderer renderer);
+
+        public XFD.TwoPaneView TwoPaneViewControl { get; }
+
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(XFD.TwoPaneView.MinTallModeHeight):
+                    TwoPaneViewControl.MinTallModeHeight = AttributeHelper.StringToDouble((string)attributeValue);
+                    break;
+                case nameof(XFD.TwoPaneView.MinWideModeWidth):
+                    TwoPaneViewControl.MinWideModeWidth = AttributeHelper.StringToDouble((string)attributeValue);
+                    break;
+                case nameof(XFD.TwoPaneView.Pane1Length):
+                    TwoPaneViewControl.Pane1Length = AttributeHelper.StringToGridLength(attributeValue, XF.GridLength.Star);
+                    break;
+                case nameof(XFD.TwoPaneView.Pane2Length):
+                    TwoPaneViewControl.Pane2Length = AttributeHelper.StringToGridLength(attributeValue, XF.GridLength.Star);
+                    break;
+                case nameof(XFD.TwoPaneView.PanePriority):
+                    TwoPaneViewControl.PanePriority = (XFD.TwoPaneViewPriority)AttributeHelper.GetInt(attributeValue);
+                    break;
+                case nameof(XFD.TwoPaneView.TallModeConfiguration):
+                    TwoPaneViewControl.TallModeConfiguration = (XFD.TwoPaneViewTallModeConfiguration)AttributeHelper.GetInt(attributeValue, (int)XFD.TwoPaneViewTallModeConfiguration.TopBottom);
+                    break;
+                case nameof(XFD.TwoPaneView.WideModeConfiguration):
+                    TwoPaneViewControl.WideModeConfiguration = (XFD.TwoPaneViewWideModeConfiguration)AttributeHelper.GetInt(attributeValue, (int)XFD.TwoPaneViewWideModeConfiguration.LeftRight);
+                    break;
+                default:
+                    base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewPane1Handler.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewPane1Handler.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public sealed class TwoPaneViewPane1Handler : ContentViewHandler
+    {
+        public TwoPaneViewPane1Handler(NativeComponentRenderer renderer, XF.ContentView twoPaneView1Control) : base(renderer, twoPaneView1Control)
+        {
+            TwoPaneView1Control = twoPaneView1Control ?? throw new ArgumentNullException(nameof(twoPaneView1Control));
+        }
+
+        public XF.ContentView TwoPaneView1Control { get; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewPane2Handler.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewPane2Handler.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public sealed class TwoPaneViewPane2Handler : ContentViewHandler
+    {
+        public TwoPaneViewPane2Handler(NativeComponentRenderer renderer, XF.ContentView twoPaneView2Control) : base(renderer, twoPaneView2Control)
+        {
+            TwoPaneView2Control = twoPaneView2Control ?? throw new ArgumentNullException(nameof(twoPaneView2Control));
+        }
+
+        public XF.ContentView TwoPaneView2Control { get; }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class TwoPaneView : Grid
+    {
+        [Parameter] public RenderFragment Pane1 { get; set; }
+        [Parameter] public RenderFragment Pane2 { get; set; }
+
+#pragma warning disable CA1721 // Property names should not match get methods
+        protected override RenderFragment GetChildContent() => RenderChildContent;
+#pragma warning restore CA1721 // Property names should not match get methods
+
+        private void RenderChildContent(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<TwoPaneViewPane1>(0);
+            builder.AddAttribute(0, nameof(TwoPaneViewPane1.ChildContent), Pane1);
+            builder.CloseComponent();
+
+            builder.OpenComponent<TwoPaneViewPane2>(1);
+            builder.AddAttribute(0, nameof(TwoPaneViewPane2.ChildContent), Pane2);
+            builder.CloseComponent();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneView.generated.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using System.Threading.Tasks;
+using XF = Xamarin.Forms;
+using XFD = Xamarin.Forms.DualScreen;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public partial class TwoPaneView : Grid
+    {
+        static TwoPaneView()
+        {
+            ElementHandlerRegistry.RegisterElementHandler<TwoPaneView>(
+                renderer => new TwoPaneViewHandler(renderer, new XFD.TwoPaneView()));
+        }
+
+        [Parameter] public double? MinTallModeHeight { get; set; }
+        [Parameter] public double? MinWideModeWidth { get; set; }
+        [Parameter] public XF.GridLength? Pane1Length { get; set; }
+        [Parameter] public XF.GridLength? Pane2Length { get; set; }
+        [Parameter] public XFD.TwoPaneViewPriority? PanePriority { get; set; }
+        [Parameter] public XFD.TwoPaneViewTallModeConfiguration? TallModeConfiguration { get; set; }
+        [Parameter] public XFD.TwoPaneViewWideModeConfiguration? WideModeConfiguration { get; set; }
+
+        public new XFD.TwoPaneView NativeControl => ((TwoPaneViewHandler)ElementHandler).TwoPaneViewControl;
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            base.RenderAttributes(builder);
+
+            if (MinTallModeHeight != null)
+            {
+                builder.AddAttribute(nameof(MinTallModeHeight), AttributeHelper.DoubleToString(MinTallModeHeight.Value));
+            }
+            if (MinWideModeWidth != null)
+            {
+                builder.AddAttribute(nameof(MinWideModeWidth), AttributeHelper.DoubleToString(MinWideModeWidth.Value));
+            }
+            if (Pane1Length != null)
+            {
+                builder.AddAttribute(nameof(Pane1Length), AttributeHelper.GridLengthToString(Pane1Length.Value));
+            }
+            if (Pane2Length != null)
+            {
+                builder.AddAttribute(nameof(Pane2Length), AttributeHelper.GridLengthToString(Pane2Length.Value));
+            }
+            if (PanePriority != null)
+            {
+                builder.AddAttribute(nameof(PanePriority), (int)PanePriority.Value);
+            }
+            if (TallModeConfiguration != null)
+            {
+                builder.AddAttribute(nameof(TallModeConfiguration), (int)TallModeConfiguration.Value);
+            }
+            if (WideModeConfiguration != null)
+            {
+                builder.AddAttribute(nameof(WideModeConfiguration), (int)WideModeConfiguration.Value);
+            }
+
+            RenderAdditionalAttributes(builder);
+        }
+
+        partial void RenderAdditionalAttributes(AttributesBuilder builder);
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane1.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane1.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+#pragma warning disable CA1812 // Internal class that is apparently never instantiated; this class is instantiated generically
+    internal class TwoPaneViewPane1 : ContentPage
+#pragma warning restore CA1812 // Internal class that is apparently never instantiated
+    {
+        static TwoPaneViewPane1()
+        {
+            // TODO: This is not quite right, but it works for now. The TwoPaneView's Pane1 and Pane2 should
+            // be placeholder controls and use ParentChildManager to set their children as the values of the
+            // Pane1 and Pane2 properties of the Xamarin.Forms control. Right now there is an XF.ContentView
+            // that is always instantiated and set as the Pane1 and Pane2 properties, and then their children
+            // are children of the XF.ContentView. This creates an unnecessary and unwanted intermediate
+            // child. It's mostly harmless, so we'll go with it for now.
+            ElementHandlerRegistry
+                .RegisterElementHandler<TwoPaneViewPane1>(renderer => new TwoPaneViewPane1Handler(renderer, new TwoPaneViewPane1View()));
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane1View.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane1View.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    internal sealed class TwoPaneViewPane1View : XF.ContentView
+    {
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane2.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane2.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+#pragma warning disable CA1812 // Internal class that is apparently never instantiated; this class is instantiated generically
+    internal class TwoPaneViewPane2 : ContentPage
+#pragma warning restore CA1812 // Internal class that is apparently never instantiated
+    {
+        static TwoPaneViewPane2()
+        {
+            ElementHandlerRegistry
+                .RegisterElementHandler<TwoPaneViewPane2>(renderer => new TwoPaneViewPane2Handler(renderer, new TwoPaneViewPane2View()));
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane2View.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/TwoPaneViewPane2View.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    internal sealed class TwoPaneViewPane2View : XF.ContentView
+    {
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Microsoft.MobileBlazorBindings.DualScreen.csproj
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Microsoft.MobileBlazorBindings.DualScreen.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Title>Experimental Forms binding for Blazor Dual Screen support</Title>
+    <Description>Support for dual screen devices for Experimental Mobile Blazor Bindings.</Description>
+    <PackageTags>blazor;mobileblazorbindings;DualScreen;twopaneview</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms.DualScreen" Version="4.7.0.968" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.MobileBlazorBindings\Microsoft.MobileBlazorBindings.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+      <FilesToSign Include="$(OutDir)\Microsoft.MobileBlazorBindings.DualScreen.dll">
+          <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- New Microsoft.MobileBlazorBindings.DualScreen project that references Xamarin.Forms.DualScreen
- New TwoPaneView component wrapper
- ComponentWrapperGenerator updated to generate TwoPaneView wrapper (but it generates it into the wrong folder)
- HelloWorldSample changed to reference new DualScreen project even though it doesn't use it (to make it easier to play with)

Related: #99 