### PR TITLE
Add IJSRuntime service to web view content in BlazorWebView

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.WebView/BlazorHybridJSRuntime.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView/BlazorHybridJSRuntime.cs
@@ -11,23 +11,26 @@ namespace Microsoft.MobileBlazorBindings.WebView
 {
     internal class BlazorHybridJSRuntime : JSRuntime
     {
-        private readonly IPC _ipc;
+        private IPC _ipc;
         private static readonly Type VoidTaskResultType = typeof(Task).Assembly
             .GetType("System.Threading.Tasks.VoidTaskResult", true);
 
-        public BlazorHybridJSRuntime(IPC ipc)
+        public BlazorHybridJSRuntime()
         {
-            _ipc = ipc ?? throw new ArgumentNullException(nameof(ipc));
             JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter());
         }
 
         protected override void BeginInvokeJS(long asyncHandle, string identifier, string argsJson)
         {
+            ThrowIfIpcNotSet();
+
             _ipc.Send("JS.BeginInvokeJS", asyncHandle, identifier, argsJson);
         }
 
         protected override void EndInvokeDotNet(DotNetInvocationInfo invocationInfo, in DotNetInvocationResult invocationResult)
         {
+            ThrowIfIpcNotSet();
+
             // The other params aren't strictly required and are only used for logging
             var resultOrError = invocationResult.Success ? HandlePossibleVoidTaskResult(invocationResult.Result) : invocationResult.Exception.ToString();
             if (resultOrError != null)
@@ -45,6 +48,19 @@ namespace Microsoft.MobileBlazorBindings.WebView
             // Looks like the TaskGenericsUtil logic in Microsoft.JSInterop doesn't know how to
             // understand System.Threading.Tasks.VoidTaskResult
             return result?.GetType() == VoidTaskResultType ? null : result;
+        }
+
+        internal void AttachToIpcChannel(IPC ipc)
+        {
+            _ipc = ipc ?? throw new ArgumentNullException(nameof(ipc));
+        }
+
+        private void ThrowIfIpcNotSet()
+        {
+            if (_ipc == null)
+            {
+                throw new InvalidOperationException($"{nameof(AttachToIpcChannel)} must be called before using {nameof(IJSRuntime)}.");
+            }
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings.WebView/BlazorHybridServiceCollectionExtensions.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView/BlazorHybridServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.JSInterop;
+using Microsoft.MobileBlazorBindings.WebView;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -12,6 +14,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddScoped<NavigationManager, BlazorHybridNavigationManager>();
             services.AddScoped<INavigationInterception, BlazorHybridNavigationInterception>();
+
+            services.AddScoped<IJSRuntime, BlazorHybridJSRuntime>();
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings.WebView/Elements/BlazorWebView.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView/Elements/BlazorWebView.cs
@@ -167,9 +167,9 @@ namespace Microsoft.MobileBlazorBindings.WebView.Elements
         // BlazorWebView directly from Xamarin Forms XAML. It only works from MBB.
         public async Task InitAsync()
         {
-            var outerServices = Services ?? BlazorHybridDefaultServices.Instance ?? DefaultServices.Value;
+            var services = Services ?? BlazorHybridDefaultServices.Instance ?? DefaultServices.Value;
+            _serviceScope = services.CreateScope();
 
-            _serviceScope = outerServices.CreateScope();
             var scopeServiceProvider = _serviceScope.ServiceProvider;
 
             var webViewJSRuntime = (BlazorHybridJSRuntime)scopeServiceProvider.GetRequiredService<IJSRuntime>();


### PR DESCRIPTION
Web-based content in BlazorWebView can now use the IJSRuntime service to do interop between .NET code and JavaScript code.

@SteveSandersonMS could you take a look at this relatively small size change? I did a bit of extra work to ensure that if there is more than one BlazorWebView (such as the HybridMessageApp sample) that they each get their own `IJSRuntime` instance because that has a reference to the IPC channel that talks to/from the inner WebView, but that they will still share all the other services (app-specific services, or other general system interfaces).

And a huge thank you to @soags for initially pointing out the problem and providing a workaround and also thank you to @arivera12 for confirming the original fix. The fix in this PR is quite different in terms of implementation for the reason I mentioned above, but the inspiration for this is from you!

Fixes #150