### PR TITLE
allow fixed version of WebView2 on Windows

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
@@ -6,6 +6,8 @@ using Microsoft.MobileBlazorBindings.WebView.Windows;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.Wpf;
 using System;
+using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using Xamarin.Forms.Platform.WPF;
@@ -61,7 +63,9 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
                     e.NewElement.RetainedNativeControl = nativeControl;
                     SetNativeControl(nativeControl);
 
-                    _coreWebView2Environment = await CoreWebView2Environment.CreateAsync().ConfigureAwait(true);
+                    var defaultPrivateWebView2InstallFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "WebView2");
+                    var privateWebView2InstallFolder = Directory.Exists(defaultPrivateWebView2InstallFolder) ? defaultPrivateWebView2InstallFolder : null;
+                    _coreWebView2Environment = await CoreWebView2Environment.CreateAsync(privateWebView2InstallFolder).ConfigureAwait(true);
 
                     await nativeControl.EnsureCoreWebView2Async(_coreWebView2Environment).ConfigureAwait(true);
 


### PR DESCRIPTION
allow user to provide a fixed-version of webview2 together when deploy, here involve a new convention that user must put webview2 under WebView2 directory. 

ref:
1. https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#fixed-version-distribution-mode
2. https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2environment.createasync?view=WebView2-dotnet-1.0.674-prerelease
3. #201