### PR TITLE
Fix elements removal for non-Layout parent

### DIFF
--- a/samples/ControlGallery/ControlGallery/AppShell.razor
+++ b/samples/ControlGallery/ControlGallery/AppShell.razor
@@ -2,7 +2,10 @@
     <TabBar Title="TabBar Title">
         <Tab Title="Tab Title">
             <ContentPage Title="Adder">
-                <Button OnClick="AddTab">Add Tab</Button>
+                <StackLayout>
+                    <Button OnClick="AddTab">Add Tab</Button>
+                    <Button IsEnabled="(count > 1)" OnClick="RemoveTab">Remove tab</Button>
+                </StackLayout>
             </ContentPage>
         </Tab>
 
@@ -20,5 +23,13 @@
     void AddTab()
     {
         count++;
+    }
+
+    void RemoveTab()
+    {
+        if (count > 1)
+        {
+            count--;
+        }
     }
 }

--- a/samples/ControlGallery/ControlGallery/AppShell.razor
+++ b/samples/ControlGallery/ControlGallery/AppShell.razor
@@ -1,6 +1,13 @@
-﻿<Shell Title="Shell Title">
-    <TabBar Title="TabBar Title">
-        <Tab Title="Tab Title">
+﻿@using ControlGallery.Views
+
+<Shell FlyoutBehavior="FlyoutBehavior.Disabled">
+    <TabBar>
+        <Tab Title="Gallery">
+            <ShellContent>
+                <PlaygroundList />
+            </ShellContent>
+        </Tab>
+        <Tab Title="Add/Remove">
             <ContentPage Title="Adder">
                 <StackLayout>
                     <Button OnClick="AddTab">Add Tab</Button>
@@ -12,7 +19,7 @@
         @for (int i = 0; i < count; i++)
         {
             var currentIndex = i;
-            <ShellTab Title="@($"Tab number {currentIndex}")" />
+            <ShellTab Title="@($"Tab #{currentIndex + 1}")" />
         }
     </TabBar>
 </Shell>

--- a/samples/ControlGallery/ControlGallery/AppShell.razor
+++ b/samples/ControlGallery/ControlGallery/AppShell.razor
@@ -1,11 +1,24 @@
-﻿@using ControlGallery.Views
-
-<Shell FlyoutBehavior="FlyoutBehavior.Disabled">
-    <TabBar>
-        <Tab>
-            <ShellContent>
-                <PlaygroundList />
-            </ShellContent>
+﻿<Shell Title="Shell Title">
+    <TabBar Title="TabBar Title">
+        <Tab Title="Tab Title">
+            <ContentPage Title="Adder">
+                <Button OnClick="AddTab">Add Tab</Button>
+            </ContentPage>
         </Tab>
+
+        @for (int i = 0; i < count; i++)
+        {
+            var currentIndex = i;
+            <ShellTab Title="@($"Tab number {currentIndex}")" />
+        }
     </TabBar>
 </Shell>
+
+@code {
+    int count = 1;
+
+    void AddTab()
+    {
+        count++;
+    }
+}

--- a/samples/ControlGallery/ControlGallery/ShellTab.razor
+++ b/samples/ControlGallery/ControlGallery/ShellTab.razor
@@ -1,0 +1,25 @@
+﻿<Tab Title="@Title">
+    @for (int i = 0; i < count; i++)
+    {
+        var currentIndex = i;
+        <ShellContent Title="@($"SC {currentIndex}")">
+            <ContentPage>
+                <StackLayout>
+                    <Label Text="@($"Tab {currentIndex}")" />
+                    <Button Text="Add shell content" OnClick="AddShellContent" />
+                </StackLayout>
+            </ContentPage>
+        </ShellContent>
+    }
+</Tab>
+
+@code {
+    [Parameter] public string Title { get; set; }
+
+    int count = 2;
+
+    void AddShellContent()
+    {
+        count++;
+    }
+}

--- a/samples/ControlGallery/ControlGallery/ShellTab.razor
+++ b/samples/ControlGallery/ControlGallery/ShellTab.razor
@@ -7,6 +7,7 @@
                 <StackLayout>
                     <Label Text="@($"Tab {currentIndex}")" />
                     <Button Text="Add shell content" OnClick="AddShellContent" />
+                    <Button IsEnabled="(count > 1)" Text="Remove shell content" OnClick="RemoveShellContent" />
                 </StackLayout>
             </ContentPage>
         </ShellContent>
@@ -21,5 +22,13 @@
     void AddShellContent()
     {
         count++;
+    }
+
+    void RemoveShellContent()
+    {
+        if (count > 1)
+        {
+            count--;
+        }
     }
 }

--- a/samples/ControlGallery/ControlGallery/ShellTab.razor
+++ b/samples/ControlGallery/ControlGallery/ShellTab.razor
@@ -2,10 +2,10 @@
     @for (int i = 0; i < count; i++)
     {
         var currentIndex = i;
-        <ShellContent Title="@($"SC {currentIndex}")">
+        <ShellContent Title="@($"Content #{currentIndex + 1}")">
             <ContentPage>
                 <StackLayout>
-                    <Label Text="@($"Tab {currentIndex}")" />
+                    <Label Text="@($"Tab {currentIndex + 1}")" />
                     <Button Text="Add shell content" OnClick="AddShellContent" />
                     <Button IsEnabled="(count > 1)" Text="Remove shell content" OnClick="RemoveShellContent" />
                 </StackLayout>

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.iOS/MobileBlazorBindingsXaminals.iOS.csproj
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.iOS/MobileBlazorBindingsXaminals.iOS.csproj
@@ -228,7 +228,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties XamarinHotReloadGenericExceptionInfoBarMobileBlazorBindingsXaminalsiOSHideInfoBar="True" />
+      <UserProperties TriggeredFromHotReload="False" XamarinHotReloadGenericExceptionInfoBarMobileBlazorBindingsXaminalsiOSHideInfoBar="True" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/src/BlinForms.Framework/BlinFormsElementManager.cs
+++ b/src/BlinForms.Framework/BlinFormsElementManager.cs
@@ -8,9 +8,9 @@ namespace BlinForms.Framework
 {
     internal class BlinFormsElementManager : ElementManager<IWindowsFormsControlHandler>
     {
-        protected override void RemoveElement(IWindowsFormsControlHandler handler)
+        protected override void RemoveChildElement(IWindowsFormsControlHandler parentHandler, IWindowsFormsControlHandler childHandler)
         {
-            handler.Control.Parent.Controls.Remove(handler.Control);
+            parentHandler.Control.Controls.Remove(childHandler.Control);
         }
 
         protected override void AddChildElement(IWindowsFormsControlHandler parentHandler, IWindowsFormsControlHandler childHandler, int physicalSiblingIndex)

--- a/src/Microsoft.MobileBlazorBindings.Core/ElementManager.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/ElementManager.cs
@@ -15,6 +15,6 @@ namespace Microsoft.MobileBlazorBindings.Core
         public abstract int GetPhysicalSiblingIndex(IElementHandler handler);
         public abstract bool IsParented(IElementHandler handler);
         public abstract bool IsParentOfChild(IElementHandler parentHandler, IElementHandler childHandler);
-        public abstract void RemoveElement(IElementHandler handler);
+        public abstract void RemoveChildElement(IElementHandler parentHandler, IElementHandler childHandler);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings.Core/ElementManagerOfElementType.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/ElementManagerOfElementType.cs
@@ -40,15 +40,15 @@ namespace Microsoft.MobileBlazorBindings.Core
             return IsParentOfChild(ConvertToType(parentHandler, nameof(parentHandler)), ConvertToType(childHandler, nameof(childHandler)));
         }
 
-        public sealed override void RemoveElement(IElementHandler handler)
+        public sealed override void RemoveChildElement(IElementHandler parentHandler, IElementHandler childHandler)
         {
-            RemoveElement(ConvertToType(handler, nameof(handler)));
+            RemoveChildElement(ConvertToType(parentHandler, nameof(parentHandler)), ConvertToType(childHandler, nameof(childHandler)));
         }
 
         protected abstract void AddChildElement(TElementType elementType1, TElementType elementType2, int physicalSiblingIndex);
         protected abstract int GetPhysicalSiblingIndex(TElementType elementType);
         protected abstract bool IsParented(TElementType elementType);
         protected abstract bool IsParentOfChild(TElementType elementType1, TElementType elementType2);
-        protected abstract void RemoveElement(TElementType elementType);
+        protected abstract void RemoveChildElement(TElementType elementType1, TElementType elementType2);
     }
 }

--- a/src/Microsoft.MobileBlazorBindings.Core/NativeComponentAdapter.cs
+++ b/src/Microsoft.MobileBlazorBindings.Core/NativeComponentAdapter.cs
@@ -137,7 +137,7 @@ namespace Microsoft.MobileBlazorBindings.Core
             {
                 // This adapter represents a physical element, so by removing it, we implicitly
                 // remove all descendants.
-                Renderer.ElementManager.RemoveElement(_targetElement);
+                Renderer.ElementManager.RemoveChildElement(_closestPhysicalParent, _targetElement);
             }
             else
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPageHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPageHandler.cs
@@ -5,12 +5,20 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class ContentPageHandler : TemplatedPageHandler
+    public partial class ContentPageHandler : TemplatedPageHandler, IXamarinFormsContainerElementHandler
     {
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsView = child as XF.View;
             ContentPageControl.Content = childAsView;
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            if (ContentPageControl.Content == child)
+            {
+                ContentPageControl.Content = null;
+            }
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPageHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPageHandler.cs
@@ -7,13 +7,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ContentPageHandler : TemplatedPageHandler, IXamarinFormsContainerElementHandler
     {
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsView = child as XF.View;
             ContentPageControl.Content = childAsView;
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             if (ContentPageControl.Content == child)
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ElementHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ElementHandler.cs
@@ -54,17 +54,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             return false;
         }
 
-
-        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
-        {
-            if (child is null)
-            {
-                throw new ArgumentNullException(nameof(child));
-            }
-
-            throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').");
-        }
-
         public virtual int GetPhysicalSiblingIndex()
         {
             // TODO: What is the set of types that support child elements? Do they all need to be special-cased here? (Maybe...)

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GestureRecognizerHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GestureRecognizerHandler.cs
@@ -40,12 +40,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
-        {
-            // This element doesn't support children
-            throw new NotSupportedException();
-        }
-
         public int GetPhysicalSiblingIndex()
         {
             // Because this is a 'fake' element, all matters related to physical trees

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridCellHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridCellHandler.cs
@@ -7,7 +7,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class GridCellHandler : IXamarinFormsElementHandler, INonChildContainerElement
+    public class GridCellHandler : IXamarinFormsContainerElementHandler, INonChildContainerElement
     {
         public GridCellHandler(NativeComponentRenderer renderer, GridCellPlaceholderElement gridCellPlaceholderElementControl)
         {
@@ -53,6 +53,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             _parentChildManager.SetChild(child);
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            // TODO: This could probably be implemented at some point, but it isn't needed right now
+            throw new NotImplementedException();
         }
 
         public int GetPhysicalSiblingIndex()

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class LabelHandler : ViewHandler, IXamarinFormsContainerElementHandler
     {
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsSpan = child as XF.Span;
 
@@ -24,7 +24,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             var childAsSpan = child as XF.Span;
 

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.cs
@@ -6,9 +6,9 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class LabelHandler : ViewHandler
+    public partial class LabelHandler : ViewHandler, IXamarinFormsContainerElementHandler
     {
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsSpan = child as XF.Span;
 
@@ -22,6 +22,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 Debug.WriteLine($"WARNING: {nameof(AddChild)} called with {nameof(physicalSiblingIndex)}={physicalSiblingIndex}, but Label.FormattedText.Spans.Count={LabelControl.FormattedText.Spans.Count}");
                 formattedString.Spans.Add(childAsSpan);
             }
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            var childAsSpan = child as XF.Span;
+
+            var formattedString = GetFormattedString();
+            formattedString.Spans.Remove(childAsSpan);
         }
 
         private XF.FormattedString GetFormattedString()

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.cs
@@ -27,12 +27,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 
         public void RemoveChild(XF.Element child)
         {
-            var physicalParent = ElementControl.Parent;
-            if (physicalParent is XF.Layout<XF.View> physicalParentAsLayout)
-            {
-                var childTargetAsView = child as XF.View;
-                physicalParentAsLayout.Children.Remove(childTargetAsView);
-            }
+            var layoutControlOfView = (XF.Layout<XF.View>)LayoutControl;
+            var childAsView = child as XF.View;
+
+            layoutControlOfView.Children.Remove(childAsView);
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             var layoutControlOfView = (XF.Layout<XF.View>)LayoutControl;
             var childAsView = child as XF.View;

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.cs
@@ -6,9 +6,9 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public abstract partial class LayoutHandler : ViewHandler
+    public abstract partial class LayoutHandler : ViewHandler, IXamarinFormsContainerElementHandler
     {
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsView = child as XF.View;
 
@@ -22,6 +22,16 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             {
                 Debug.WriteLine($"WARNING: {nameof(AddChild)} called with {nameof(physicalSiblingIndex)}={physicalSiblingIndex}, but layoutControlOfView.Children.Count={layoutControlOfView.Children.Count}");
                 layoutControlOfView.Children.Add(childAsView);
+            }
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            var physicalParent = ElementControl.Parent;
+            if (physicalParent is XF.Layout<XF.View> physicalParentAsLayout)
+            {
+                var childTargetAsView = child as XF.View;
+                physicalParentAsLayout.Children.Remove(childTargetAsView);
             }
         }
     }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             MasterDetailPageControl.Detail = new XF.Page();
         }
 
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
@@ -47,7 +47,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             if (child is null)
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MasterDetailPageHandler.cs
@@ -7,7 +7,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class MasterDetailPageHandler : PageHandler
+    public partial class MasterDetailPageHandler : PageHandler, IXamarinFormsContainerElementHandler
     {
 #pragma warning disable IDE0060 // Remove unused parameter
 #pragma warning disable CA1801 // Parameter is never used
@@ -26,7 +26,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             MasterDetailPageControl.Detail = new XF.Page();
         }
 
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
@@ -44,6 +44,27 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             else
             {
                 throw new InvalidOperationException($"Unknown child type {child.GetType().FullName} being added to parent element type {GetType().FullName}.");
+            }
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            if (child is null)
+            {
+                throw new ArgumentNullException(nameof(child));
+            }
+
+            if (child == MasterDetailPageControl.Master)
+            {
+                MasterDetailPageControl.Master = new XF.Page() { Title = "Title" };
+            }
+            else if (child == MasterDetailPageControl.Detail)
+            {
+                MasterDetailPageControl.Detail = new XF.Page();
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unknown child type {child.GetType().FullName} being removed from parent element type {GetType().FullName}.");
             }
         }
     }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ModalContainerHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ModalContainerHandler.cs
@@ -7,7 +7,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class ModalContainerHandler : IXamarinFormsElementHandler, INonChildContainerElement
+    public class ModalContainerHandler : IXamarinFormsContainerElementHandler, INonChildContainerElement
     {
         public ModalContainerHandler(NativeComponentRenderer renderer, DummyElement modalContainerDummyControl)
         {
@@ -77,6 +77,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             _parentChildManager.SetChild(child);
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            // TODO: This could probably be implemented at some point, but it isn't needed right now
+            throw new NotImplementedException();
         }
 
         public bool IsParented()

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellContentHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellContentHandler.cs
@@ -8,13 +8,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellContentHandler : BaseShellItemHandler, IXamarinFormsContainerElementHandler
     {
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsTemplatedPage = child as XF.TemplatedPage;
             ShellContentControl.Content = childAsTemplatedPage;
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             if (ShellContentControl.Content == child)
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellContentHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellContentHandler.cs
@@ -6,12 +6,20 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class ShellContentHandler : BaseShellItemHandler
+    public partial class ShellContentHandler : BaseShellItemHandler, IXamarinFormsContainerElementHandler
     {
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsTemplatedPage = child as XF.TemplatedPage;
             ShellContentControl.Content = childAsTemplatedPage;
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            if (ShellContentControl.Content == child)
+            {
+                ShellContentControl.Content = null;
+            }
         }
 
         public override void SetParent(XF.Element parent)

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellFlyoutHeaderHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellFlyoutHeaderHandler.cs
@@ -7,7 +7,7 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public class ShellFlyoutHeaderHandler : IXamarinFormsElementHandler, INonChildContainerElement
+    public class ShellFlyoutHeaderHandler : IXamarinFormsContainerElementHandler, INonChildContainerElement
     {
         public ShellFlyoutHeaderHandler(NativeComponentRenderer renderer, DummyElement shellFlyoutHeaderDummyControl)
         {
@@ -36,6 +36,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             _parentChildManager.SetChild(child);
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            // TODO: This could probably be implemented at some point, but it isn't needed right now
+            throw new NotImplementedException();
         }
 
         public int GetPhysicalSiblingIndex()

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         public ulong NavigatedEventHandlerId { get; set; }
         public ulong NavigatingEventHandlerId { get; set; }
 
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
@@ -76,7 +76,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             if (child is null)
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.cs
@@ -3,11 +3,13 @@
 
 using Microsoft.MobileBlazorBindings.Core;
 using System;
+using System.Diagnostics;
+using System.Linq;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class ShellHandler : PageHandler
+    public partial class ShellHandler : PageHandler, IXamarinFormsContainerElementHandler
     {
         private readonly XF.ContentView _flyoutHeaderContentView = new XF.ContentView();
 
@@ -46,33 +48,79 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         public ulong NavigatedEventHandlerId { get; set; }
         public ulong NavigatingEventHandlerId { get; set; }
 
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
                 throw new ArgumentNullException(nameof(child));
             }
 
-            switch (child)
+            XF.ShellItem itemToAdd = child switch
             {
-                case XF.TemplatedPage childAsTemplatedPage:
-                    ShellControl.Items.Add(childAsTemplatedPage); // Implicit conversion
-                    break;
-                case XF.ShellContent childAsShellContent:
-                    ShellControl.Items.Add(childAsShellContent); // Implicit conversion
-                    break;
-                case XF.ShellSection childAsShellSection:
-                    ShellControl.Items.Add(childAsShellSection); // Implicit conversion
-                    break;
-                case XF.MenuItem childAsMenuItem:
-                    ShellControl.Items.Add(childAsMenuItem); // Implicit conversion
-                    break;
-                case XF.ShellItem childAsShellItem:
-                    ShellControl.Items.Add(childAsShellItem);
-                    break;
-                default:
-                    throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').");
+                XF.TemplatedPage childAsTemplatedPage => childAsTemplatedPage, // Implicit conversion
+                XF.ShellContent childAsShellContent => childAsShellContent, // Implicit conversion
+                XF.ShellSection childAsShellSection => childAsShellSection, // Implicit conversion
+                XF.MenuItem childAsMenuItem => childAsMenuItem, // Implicit conversion
+                XF.ShellItem childAsShellItem => childAsShellItem,
+                _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').")
+            };
+
+            if (ShellControl.Items.Count >= physicalSiblingIndex)
+            {
+                ShellControl.Items.Insert(physicalSiblingIndex, itemToAdd);
             }
+            else
+            {
+                Debug.WriteLine($"WARNING: {nameof(AddChild)} called with {nameof(physicalSiblingIndex)}={physicalSiblingIndex}, but ShellControl.Items.Count={ShellControl.Items.Count}");
+                ShellControl.Items.Add(itemToAdd);
+            }
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            if (child is null)
+            {
+                throw new ArgumentNullException(nameof(child));
+            }
+
+            var itemToRemove = child switch
+            {
+                XF.TemplatedPage childAsTemplatedPage => GetItemForTemplatedPage(childAsTemplatedPage),
+                XF.ShellContent childAsShellContent => GetItemForContent(childAsShellContent),
+                XF.ShellSection childAsShellSection => GetItemForSection(childAsShellSection),
+                XF.MenuItem childAsMenuItem => GetItemForMenuItem(childAsMenuItem),
+                XF.ShellItem childAsShellItem => childAsShellItem,
+                _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support removing a child (child type is '{child.GetType().FullName}').")
+            };
+
+            ShellControl.Items.Remove(itemToRemove);
+        }
+
+        private XF.ShellItem GetItemForTemplatedPage(XF.TemplatedPage childAsTemplatedPage)
+        {
+            return ShellControl.Items
+                .FirstOrDefault(item => item.Items
+                    .Any(section => section.Items.Any(content => content.Content == childAsTemplatedPage)));
+        }
+
+        private XF.ShellItem GetItemForContent(XF.ShellContent childAsShellContent)
+        {
+            return ShellControl.Items
+                .FirstOrDefault(item => item.Items
+                    .Any(section => section.Items.Contains(childAsShellContent)));
+        }
+
+        private XF.ShellItem GetItemForSection(XF.ShellSection childAsShellSection)
+        {
+            return ShellControl.Items.FirstOrDefault(item => item.Items.Contains(childAsShellSection));
+        }
+
+        private XF.ShellItem GetItemForMenuItem(XF.MenuItem childAsMenuItem)
+        {
+            // MenuItem is wrapped in ShellMenuItem, which is internal type.
+            // Not sure how to identify this item correctly.
+            return ShellControl.Items.FirstOrDefault(item => item.Title == childAsMenuItem.Text 
+                && item.Items.Count == 0);
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellItemHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellItemHandler.cs
@@ -2,33 +2,56 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class ShellItemHandler : ShellGroupItemHandler
+    public partial class ShellItemHandler : ShellGroupItemHandler, IXamarinFormsContainerElementHandler
     {
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
                 throw new ArgumentNullException(nameof(child));
             }
 
-            switch (child)
+            XF.ShellSection sectionToAdd = child switch
             {
-                case XF.TemplatedPage childAsTemplatedPage:
-                    ShellItemControl.Items.Add(childAsTemplatedPage); // Implicit conversion
-                    break;
-                case XF.ShellContent childAsShellContent:
-                    ShellItemControl.Items.Add(childAsShellContent); // Implicit conversion
-                    break;
-                case XF.ShellSection childAsShellSection:
-                    ShellItemControl.Items.Add(childAsShellSection);
-                    break;
-                default:
-                    throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').");
+                XF.TemplatedPage childAsTemplatedPage => childAsTemplatedPage,  // Implicit conversion
+                XF.ShellContent childAsShellContent => childAsShellContent,  // Implicit conversion
+                XF.ShellSection childAsShellSection => childAsShellSection,
+                _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').")
+            };
+
+            if (ShellItemControl.Items.Count >= physicalSiblingIndex)
+            {
+                ShellItemControl.Items.Insert(physicalSiblingIndex, sectionToAdd);
             }
+            else
+            {
+                Debug.WriteLine($"WARNING: {nameof(AddChild)} called with {nameof(physicalSiblingIndex)}={physicalSiblingIndex}, but ShellItemControl.Items.Count={ShellItemControl.Items.Count}");
+                ShellItemControl.Items.Add(sectionToAdd);
+            }
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            if (child is null)
+            {
+                throw new ArgumentNullException(nameof(child));
+            }
+
+            var sectionToRemove = child switch
+            {
+                XF.TemplatedPage childAsTemplatedPage => GetSectionForTemplatedPage(childAsTemplatedPage),
+                XF.ShellContent childAsShellContent => GetSectionForContent(childAsShellContent),
+                XF.ShellSection childAsShellSection => childAsShellSection,
+                _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support removing a child (child type is '{child.GetType().FullName}').")
+            };
+
+            ShellItemControl.Items.Remove(sectionToRemove);
         }
 
         public override void SetParent(XF.Element parent)
@@ -38,6 +61,17 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 // The Parent should already be set
                 throw new InvalidOperationException("Shouldn't need to set parent here...");
             }
+        }
+
+        private XF.ShellSection GetSectionForContent(XF.ShellContent shellContent)
+        {
+            return ShellItemControl.Items.FirstOrDefault(section => section.Items.Contains(shellContent));
+        }
+
+        private XF.ShellSection GetSectionForTemplatedPage(XF.TemplatedPage templatedPage)
+        {
+            return ShellItemControl.Items
+                .FirstOrDefault(section => section.Items.Any(contect => contect.Content == templatedPage));
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellItemHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellItemHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellItemHandler : ShellGroupItemHandler, IXamarinFormsContainerElementHandler
     {
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
@@ -36,7 +36,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             if (child is null)
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
@@ -2,30 +2,54 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class ShellSectionHandler : ShellGroupItemHandler
+    public partial class ShellSectionHandler : ShellGroupItemHandler, IXamarinFormsContainerElementHandler
     {
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
                 throw new ArgumentNullException(nameof(child));
             }
 
-            switch (child)
+            XF.ShellContent contentToAdd = child switch
             {
-                case XF.TemplatedPage childAsTemplatedPage:
-                    ShellSectionControl.Items.Add(childAsTemplatedPage); // Implicit conversion
-                    break;
-                case XF.ShellContent childAsShellContent:
-                    ShellSectionControl.Items.Add(childAsShellContent);
-                    break;
-                default:
-                    throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').");
+                XF.TemplatedPage childAsTemplatedPage => childAsTemplatedPage,  // Implicit conversion
+                XF.ShellContent childAsShellContent => childAsShellContent,
+                _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').")
+            };
+
+            if (ShellSectionControl.Items.Count >= physicalSiblingIndex)
+            {
+                ShellSectionControl.Items.Insert(physicalSiblingIndex, contentToAdd);
             }
+            else
+            {
+                Debug.WriteLine($"WARNING: {nameof(AddChild)} called with {nameof(physicalSiblingIndex)}={physicalSiblingIndex}, but ShellSectionControl.Items.Count={ShellSectionControl.Items.Count}");
+                ShellSectionControl.Items.Add(contentToAdd);
+            }
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            if (child is null)
+            {
+                throw new ArgumentNullException(nameof(child));
+            }
+
+            XF.ShellContent contentToRemove = child switch
+            {
+                XF.TemplatedPage childAsTemplatedPage => GetContentForTemplatePage(childAsTemplatedPage),
+                XF.ShellContent childAsShellContent => childAsShellContent,
+                _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support removing a child (child type is '{child.GetType().FullName}').")
+            };
+
+            ShellSectionControl.Items.Remove(contentToRemove);
         }
 
         public override void SetParent(XF.Element parent)
@@ -35,6 +59,11 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 // The Parent should already be set
                 throw new InvalidOperationException("Shouldn't need to set parent here...");
             }
+        }
+
+        private XF.ShellContent GetContentForTemplatePage(XF.TemplatedPage childAsTemplatedPage)
+        {
+            return ShellSectionControl.Items.FirstOrDefault(content => content.Content == childAsTemplatedPage);
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellSectionHandler : ShellGroupItemHandler, IXamarinFormsContainerElementHandler
     {
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             if (child is null)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             if (child is null)
             {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
@@ -24,6 +24,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').")
             };
 
+            // Ensure that there is non-null Content to avoid exceptions in Xamarin.Forms
             contentToAdd.Content ??= new XF.Page();
 
             if (ShellSectionControl.Items.Count >= physicalSiblingIndex)

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.cs
@@ -24,6 +24,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 _ => throw new NotSupportedException($"Handler of type '{GetType().FullName}' representing element type '{TargetElement?.GetType().FullName ?? "<null>"}' doesn't support adding a child (child type is '{child.GetType().FullName}').")
             };
 
+            contentToAdd.Content ??= new XF.Page();
+
             if (ShellSectionControl.Items.Count >= physicalSiblingIndex)
             {
                 ShellSectionControl.Items.Insert(physicalSiblingIndex, contentToAdd);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StyleSheetHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StyleSheetHandler.cs
@@ -48,11 +48,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
-        {
-            throw new NotImplementedException();
-        }
-
         public int GetPhysicalSiblingIndex()
         {
             return 0;

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.cs
@@ -8,7 +8,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TabbedPageHandler : PageHandler, IXamarinFormsContainerElementHandler
     {
-        public void AddChild(XF.Element child, int physicalSiblingIndex)
+        public virtual void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsPage = child as XF.Page;
 
@@ -23,7 +23,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             }
         }
 
-        public void RemoveChild(XF.Element child)
+        public virtual void RemoveChild(XF.Element child)
         {
             TabbedPageControl.Children.Remove(child as XF.Page);
         }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.cs
@@ -6,9 +6,9 @@ using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
-    public partial class TabbedPageHandler : PageHandler
+    public partial class TabbedPageHandler : PageHandler, IXamarinFormsContainerElementHandler
     {
-        public override void AddChild(XF.Element child, int physicalSiblingIndex)
+        public void AddChild(XF.Element child, int physicalSiblingIndex)
         {
             var childAsPage = child as XF.Page;
 
@@ -21,6 +21,11 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 Debug.WriteLine($"WARNING: {nameof(AddChild)} called with {nameof(physicalSiblingIndex)}={physicalSiblingIndex}, but TabbedPageControl.Children.Count={TabbedPageControl.Children.Count}");
                 TabbedPageControl.Children.Add(childAsPage);
             }
+        }
+
+        public void RemoveChild(XF.Element child)
+        {
+            TabbedPageControl.Children.Remove(child as XF.Page);
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/IXamarinFormsContainerElementHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/IXamarinFormsContainerElementHandler.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings
+{
+    public interface IXamarinFormsContainerElementHandler : IXamarinFormsElementHandler
+    {
+        void AddChild(XF.Element child, int physicalSiblingIndex);
+        void RemoveChild(XF.Element child);
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/IXamarinFormsElementHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/IXamarinFormsElementHandler.cs
@@ -10,7 +10,6 @@ namespace Microsoft.MobileBlazorBindings
     {
         XF.Element ElementControl { get; }
 
-        void AddChild(XF.Element child, int physicalSiblingIndex);
         bool IsParented();
         bool IsParentedTo(XF.Element parent);
         void SetParent(XF.Element parent);

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
@@ -43,7 +43,14 @@ namespace Microsoft.MobileBlazorBindings
                 return;
             }
 
-            parentHandler.AddChild(childHandler.ElementControl, physicalSiblingIndex);
+            if (!(parentHandler is IXamarinFormsContainerElementHandler parent))
+            {
+                throw new NotSupportedException($"Handler of type '{parentHandler.GetType().FullName}' representing element type " +
+                    $"'{parentHandler.ElementControl?.GetType().FullName ?? "<null>"}' doesn't support adding a child " +
+                    $"(child type is '{childHandler.ElementControl?.GetType().FullName}').");
+            }
+
+            parent.AddChild(childHandler.ElementControl, physicalSiblingIndex);
 
             if (!(parentHandler is INonChildContainerElement))
             {
@@ -62,14 +69,15 @@ namespace Microsoft.MobileBlazorBindings
 
         protected override void RemoveChildElement(IXamarinFormsElementHandler parentHandler, IXamarinFormsElementHandler childHandler)
         {
-            // TODO: Need to make this logic more generic; not all parents are Layouts, not all children are Views
-
-            var control = childHandler.ElementControl;
-            var physicalParent = parentHandler.ElementControl;
-            if (physicalParent is Layout<View> physicalParentAsLayout)
+            if (parentHandler is IXamarinFormsContainerElementHandler parent)
             {
-                var childTargetAsView = control as View;
-                physicalParentAsLayout.Children.Remove(childTargetAsView);
+                parent.RemoveChild(childHandler.ElementControl);
+            }
+            else
+            {
+                throw new NotSupportedException($"Handler of type '{parentHandler.GetType().FullName}' representing element type " +
+                    $"'{parentHandler.ElementControl?.GetType().FullName ?? "<null>"}' doesn't support removing a child " +
+                    $"(child type is '{childHandler.ElementControl?.GetType().FullName}').");
             }
         }
 

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsElementManager.cs
@@ -60,12 +60,12 @@ namespace Microsoft.MobileBlazorBindings
             return handler.GetPhysicalSiblingIndex();
         }
 
-        protected override void RemoveElement(IXamarinFormsElementHandler handler)
+        protected override void RemoveChildElement(IXamarinFormsElementHandler parentHandler, IXamarinFormsElementHandler childHandler)
         {
             // TODO: Need to make this logic more generic; not all parents are Layouts, not all children are Views
 
-            var control = handler.ElementControl;
-            var physicalParent = control.Parent;
+            var control = childHandler.ElementControl;
+            var physicalParent = parentHandler.ElementControl;
             if (physicalParent is Layout<View> physicalParentAsLayout)
             {
                 var childTargetAsView = control as View;


### PR DESCRIPTION
fixes #217 


- `ElementManager`'s method `RemoveElement(IElementHandler handler)` is replaced with `RemoveChildElement(IElementHandler parentHandler, IElementHandler childHandler)`
- Instead of handling child's element removal in MobileBlazorBindingsElementManager, it delegates removal to parent's `RemoveChild` method.
- Implemented `RemoveChild` method for all container elements handlers.
- Fixed `AddChild` method for some Shell controls handlers to handle `physicalSiblingIndex` argument.

Implementing `RemoveChild` for some Shell elements was a little bit tricky - because of implicit conversions `AddChild` method can actually add multiple elements, and we need to identify which ShellItem to remove (e.g. when you add `TemplatedPage` to `Shell` it actually adds `ShellItem` -> `ShellSection` -> `ShellContent` -> `TempletedPage`).

I decided to move methods `AddChild` and `RemoveChild` to separate interface `IXamarinFormsContainerElementHandler`, it seemed like a better option to me. Let me know if you'd prefer it other way.


Example:
<details>
  <summary>AppShell.razor</summary>

  ```razor
<Shell>
    <TabBar>
        @if (firstTabDisplayed)
        {
            <Tab Title="Tab1">
                <ContentPage>
                    <StackLayout>
                        <Label Text="Tab1" />
                        <Button Text="Switch tab" OnClick="SwitchTab" />
                    </StackLayout>
                </ContentPage>
            </Tab>
        }
        else
        {
            <Tab Title="Tab2">
                <ContentPage>
                    <StackLayout>
                        <Label Text="Tab2" />
                        <Button Text="Switch tab" OnClick="SwitchTab" />
                    </StackLayout>
                </ContentPage>
            </Tab>
        }
    </TabBar>
</Shell>

@code { 
    bool firstTabDisplayed = true;

    void SwitchTab()
    {
        firstTabDisplayed = !firstTabDisplayed;
    }
}
  ```
  
</details>


<details>
<summary>Before</summary>

![4CsyhaXgu8](https://user-images.githubusercontent.com/17177729/98307126-c3488a80-1fcd-11eb-9ecc-26e30e15ce85.gif)

</details>

<details>
<summary>After</summary>

![hQfoqSL9E1](https://user-images.githubusercontent.com/17177729/98307155-cf344c80-1fcd-11eb-9f2f-d1b70c791b4d.gif)


</details>