### PR TITLE
Nuget updates. Fixes #244.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/samples/ControlGallery/ControlGallery.Android/ControlGallery.Android.csproj
+++ b/samples/ControlGallery/ControlGallery.Android/ControlGallery.Android.csproj
@@ -56,9 +56,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Forms">
-      <Version>2.80.1</Version>
+      <Version>2.80.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/ControlGallery/ControlGallery.iOS/ControlGallery.iOS.csproj
+++ b/samples/ControlGallery/ControlGallery.iOS/ControlGallery.iOS.csproj
@@ -123,9 +123,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Forms">
-      <Version>2.80.1</Version>
+      <Version>2.80.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/samples/ControlGallery/ControlGallery/ControlGallery.csproj
+++ b/samples/ControlGallery/ControlGallery/ControlGallery.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.2" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
 

--- a/samples/HybridApp/HybridApp.Android/HybridApp.Android.csproj
+++ b/samples/HybridApp/HybridApp.Android/HybridApp.Android.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="System.Text.Encodings.Web">
       <Version>4.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/HybridApp/HybridApp.Windows/HybridApp.Windows.csproj
+++ b/samples/HybridApp/HybridApp.Windows/HybridApp.Windows.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.8.0.1451" NoWarn="NU1701" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.8.0.1687" NoWarn="NU1701" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/HybridApp/HybridApp.iOS/HybridApp.iOS.csproj
+++ b/samples/HybridApp/HybridApp.iOS/HybridApp.iOS.csproj
@@ -122,7 +122,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />
   </ItemGroup>
@@ -147,7 +147,6 @@
       <UserProperties XamarinHotReloadGenericExceptionInfoBarHybridAppiOSHideInfoBar="True" />
     </VisualStudio>
   </ProjectExtensions>
-
   <!-- Normally this import would be automatic through the nuget package. We do it manually for projects inside this solution. -->
   <Import Project="..\..\..\src\Microsoft.MobileBlazorBindings.WebView.iOS\build\Microsoft.MobileBlazorBindings.WebView.iOS.targets" />
 </Project>

--- a/samples/HybridApp/HybridApp.macOS/HybridApp.macOS.csproj
+++ b/samples/HybridApp/HybridApp.macOS/HybridApp.macOS.csproj
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Normally this import would be automatic through the nuget package. We do it manually for projects inside this solution. -->
   <Import Project="..\..\..\src\Microsoft.MobileBlazorBindings.WebView.macOS\build\Microsoft.MobileBlazorBindings.WebView.macOS.props" />
-
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -94,7 +93,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />
   </ItemGroup>
@@ -112,7 +111,6 @@
   <ItemGroup>
     <Content Include="Resources\wwwroot\index.html" />
   </ItemGroup>
-
   <!-- Normally this import would be automatic through the nuget package. We do it manually for projects inside this solution. -->
   <Import Project="..\..\..\src\Microsoft.MobileBlazorBindings.WebView.macOS\build\Microsoft.MobileBlazorBindings.WebView.macOS.targets" />
 </Project>

--- a/samples/HybridMessageApp/HybridMessageApp.Android/HybridMessageApp.Android.csproj
+++ b/samples/HybridMessageApp/HybridMessageApp.Android/HybridMessageApp.Android.csproj
@@ -54,7 +54,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/HybridMessageApp/HybridMessageApp.Windows/HybridMessageApp.Windows.csproj
+++ b/samples/HybridMessageApp/HybridMessageApp.Windows/HybridMessageApp.Windows.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.8.0.1451" NoWarn="NU1701" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.8.0.1687" NoWarn="NU1701" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/HybridMessageApp/HybridMessageApp.iOS/HybridMessageApp.iOS.csproj
+++ b/samples/HybridMessageApp/HybridMessageApp.iOS/HybridMessageApp.iOS.csproj
@@ -135,7 +135,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />
   </ItemGroup>
@@ -160,7 +160,6 @@
       <UserProperties TriggeredFromHotReload="False" />
     </VisualStudio>
   </ProjectExtensions>
-
   <!-- Normally this import would be automatic through the nuget package. We do it manually for projects inside this solution. -->
   <Import Project="..\..\..\src\Microsoft.MobileBlazorBindings.WebView.iOS\build\Microsoft.MobileBlazorBindings.WebView.iOS.targets" />
 </Project>

--- a/samples/HybridMessageApp/HybridMessageApp/HybridMessageApp.csproj
+++ b/samples/HybridMessageApp/HybridMessageApp/HybridMessageApp.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.5" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.10" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
 

--- a/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.Android/MobileBlazorBindingsHelloWorld.Android.csproj
+++ b/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.Android/MobileBlazorBindingsHelloWorld.Android.csproj
@@ -54,7 +54,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.iOS/MobileBlazorBindingsHelloWorld.iOS.csproj
+++ b/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.iOS/MobileBlazorBindingsHelloWorld.iOS.csproj
@@ -122,7 +122,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.csproj
+++ b/samples/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld/MobileBlazorBindingsHelloWorld.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
 

--- a/samples/MobileBlazorBindingsTodoSample/MobileBlazorBindingsTodo.Android/MobileBlazorBindingsTodo.Android.csproj
+++ b/samples/MobileBlazorBindingsTodoSample/MobileBlazorBindingsTodo.Android/MobileBlazorBindingsTodo.Android.csproj
@@ -54,7 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MobileBlazorBindingsTodoSample/MobileBlazorBindingsTodo.iOS/MobileBlazorBindingsTodo.iOS.csproj
+++ b/samples/MobileBlazorBindingsTodoSample/MobileBlazorBindingsTodo.iOS/MobileBlazorBindingsTodo.iOS.csproj
@@ -130,7 +130,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/samples/MobileBlazorBindingsTodoSample/MobileBlazorBindingsTodo/MobileBlazorBindingsTodo.csproj
+++ b/samples/MobileBlazorBindingsTodoSample/MobileBlazorBindingsTodo/MobileBlazorBindingsTodo.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="sqlite-net-pcl" Version="1.6.292" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="sqlite-net-pcl" Version="1.7.335" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
 

--- a/samples/MobileBlazorBindingsWeather/Microsoft.MobileBlazorBindings.PancakeView/Microsoft.MobileBlazorBindings.PancakeView.csproj
+++ b/samples/MobileBlazorBindingsWeather/Microsoft.MobileBlazorBindings.PancakeView/Microsoft.MobileBlazorBindings.PancakeView.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms.PancakeView" Version="1.3.4" />
+    <PackageReference Include="Xamarin.Forms.PancakeView" Version="1.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather.Android/MobileBlazorBindingsWeather.Android.csproj
+++ b/samples/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather.Android/MobileBlazorBindingsWeather.Android.csproj
@@ -54,7 +54,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather.iOS/MobileBlazorBindingsWeather.iOS.csproj
+++ b/samples/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather.iOS/MobileBlazorBindingsWeather.iOS.csproj
@@ -120,7 +120,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/samples/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather.csproj
+++ b/samples/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather/MobileBlazorBindingsWeather.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.Android/MobileBlazorBindingsXaminals.Android.csproj
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.Android/MobileBlazorBindingsXaminals.Android.csproj
@@ -54,7 +54,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.iOS/MobileBlazorBindingsXaminals.iOS.csproj
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.iOS/MobileBlazorBindingsXaminals.iOS.csproj
@@ -120,7 +120,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
   <ItemGroup>
@@ -228,7 +228,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties TriggeredFromHotReload="False" XamarinHotReloadGenericExceptionInfoBarMobileBlazorBindingsXaminalsiOSHideInfoBar="True" />
+      <UserProperties XamarinHotReloadGenericExceptionInfoBarMobileBlazorBindingsXaminalsiOSHideInfoBar="True" TriggeredFromHotReload="False" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.csproj
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>
 

--- a/src/BlinForms.Framework/BlinForms.Framework.csproj
+++ b/src/BlinForms.Framework/BlinForms.Framework.csproj
@@ -10,11 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.10" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ComponentWrapperGenerator/ComponentWrapperGenerator.csproj
+++ b/src/ComponentWrapperGenerator/ComponentWrapperGenerator.csproj
@@ -16,16 +16,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451">
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687">
       <IncludeAssets></IncludeAssets>
       <PrivateAssets></PrivateAssets>
       <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms.DualScreen" Version="4.8.0.1451">
+    <PackageReference Include="Xamarin.Forms.DualScreen" Version="4.8.0.1687">
       <IncludeAssets></IncludeAssets>
       <PrivateAssets></PrivateAssets>
       <GeneratePathProperty>true</GeneratePathProperty>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Microsoft.MobileBlazorBindings.Core/Microsoft.MobileBlazorBindings.Core.csproj
+++ b/src/Microsoft.MobileBlazorBindings.Core/Microsoft.MobileBlazorBindings.Core.csproj
@@ -18,13 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Microsoft.MobileBlazorBindings.DualScreen.csproj
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Microsoft.MobileBlazorBindings.DualScreen.csproj
@@ -8,15 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms.DualScreen" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms.DualScreen" Version="4.8.0.1687" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.MobileBlazorBindings.SkiaSharp/Microsoft.MobileBlazorBindings.SkiaSharp.csproj
+++ b/src/Microsoft.MobileBlazorBindings.SkiaSharp/Microsoft.MobileBlazorBindings.SkiaSharp.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.2" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,6 +24,10 @@
     <FilesToSign Include="$(OutDir)\Microsoft.MobileBlazorBindings.SkiaSharp.dll">
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.SkiaSharp/Microsoft.MobileBlazorBindings.SkiaSharp.csproj
+++ b/src/Microsoft.MobileBlazorBindings.SkiaSharp/Microsoft.MobileBlazorBindings.SkiaSharp.csproj
@@ -25,9 +25,4 @@
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.UnitTests/Microsoft.MobileBlazorBindings.UnitTests.csproj
+++ b/src/Microsoft.MobileBlazorBindings.UnitTests/Microsoft.MobileBlazorBindings.UnitTests.csproj
@@ -16,9 +16,4 @@
     <ProjectReference Include="..\Microsoft.MobileBlazorBindings.Core\Microsoft.MobileBlazorBindings.Core.csproj" />
     <ProjectReference Include="..\Microsoft.MobileBlazorBindings\Microsoft.MobileBlazorBindings.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.UnitTests/Microsoft.MobileBlazorBindings.UnitTests.csproj
+++ b/src/Microsoft.MobileBlazorBindings.UnitTests/Microsoft.MobileBlazorBindings.UnitTests.csproj
@@ -8,13 +8,17 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.MobileBlazorBindings.Core\Microsoft.MobileBlazorBindings.Core.csproj" />
     <ProjectReference Include="..\Microsoft.MobileBlazorBindings\Microsoft.MobileBlazorBindings.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView.Android/Microsoft.MobileBlazorBindings.WebView.Android.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Android/Microsoft.MobileBlazorBindings.WebView.Android.csproj
@@ -31,14 +31,14 @@
     <AndroidResource Include="Resources\**\*.xml" SubType="Designer" Generator="MSBuild:UpdateAndroidResources" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
 
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.0.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.2.4.1" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.1.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.ViewPager" Version="1.0.0.1" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.5" />
+    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.2.0.2" />
+    <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.2.5.3" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.5" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.3" />
+    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.1.1.5" />
+    <PackageReference Include="Xamarin.AndroidX.ViewPager" Version="1.0.0.5" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0.1" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
@@ -54,5 +54,9 @@
     <FilesToSign Include="$(OutDir)\Microsoft.MobileBlazorBindings.WebView.Android.dll">
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView.Android/Microsoft.MobileBlazorBindings.WebView.Android.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Android/Microsoft.MobileBlazorBindings.WebView.Android.csproj
@@ -55,8 +55,4 @@
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView.JS/Microsoft.MobileBlazorBindings.WebView.JS.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.JS/Microsoft.MobileBlazorBindings.WebView.JS.csproj
@@ -55,6 +55,10 @@
     <None Include="webpack.config.js" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
+  </ItemGroup>
+
   <Target Name="EnsureNpmRestored" Condition="!Exists('node_modules')">
     <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
     <Exec Command="npm install" />

--- a/src/Microsoft.MobileBlazorBindings.WebView.JS/Microsoft.MobileBlazorBindings.WebView.JS.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.JS/Microsoft.MobileBlazorBindings.WebView.JS.csproj
@@ -55,10 +55,6 @@
     <None Include="webpack.config.js" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
-
   <Target Name="EnsureNpmRestored" Condition="!Exists('node_modules')">
     <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
     <Exec Command="npm install" />

--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/Microsoft.MobileBlazorBindings.WebView.Windows.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/Microsoft.MobileBlazorBindings.WebView.Windows.csproj
@@ -27,10 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.674-prerelease" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.664.37" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.8.0.1451" NoWarn="NU1701" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="4.8.0.1687" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -47,5 +47,8 @@
       <FilesToSign Include="$(OutDir)\Microsoft.MobileBlazorBindings.WebView.Windows.dll">
           <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/Microsoft.MobileBlazorBindings.WebView.Windows.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/Microsoft.MobileBlazorBindings.WebView.Windows.csproj
@@ -48,7 +48,4 @@
           <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
+++ b/src/Microsoft.MobileBlazorBindings.WebView.Windows/WebViewExtendedAnaheimRenderer.cs
@@ -156,7 +156,7 @@ namespace Microsoft.MobileBlazorBindings.WebView.Windows
                 if (responseStream != null) // If null, the handler doesn't want to handle it
                 {
                     responseStream.Position = 0;
-                    args.Response = Control.CoreWebView2.Environment.CreateWebResourceResponse(responseStream, StatusCode: 200, ReasonPhrase: "OK", Headers: $"Content-Type: {responseContentType}{Environment.NewLine}Cache-Control: no-cache, max-age=0, must-revalidate, no-store");
+                    args.Response = _coreWebView2Environment.CreateWebResourceResponse(responseStream, StatusCode: 200, ReasonPhrase: "OK", Headers: $"Content-Type: {responseContentType}{Environment.NewLine}Cache-Control: no-cache, max-age=0, must-revalidate, no-store");
                 }
             }
         }

--- a/src/Microsoft.MobileBlazorBindings.WebView.iOS/Microsoft.MobileBlazorBindings.WebView.iOS.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.iOS/Microsoft.MobileBlazorBindings.WebView.iOS.csproj
@@ -51,10 +51,6 @@
     </FilesToSign>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
-
   <!-- See comment at top of file about manually importing SDK -->
   <Import Project="Sdk.targets" Sdk="MSBuild.Sdk.Extras" />
   <!--

--- a/src/Microsoft.MobileBlazorBindings.WebView.iOS/Microsoft.MobileBlazorBindings.WebView.iOS.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.iOS/Microsoft.MobileBlazorBindings.WebView.iOS.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -49,6 +49,10 @@
     <FilesToSign Include="$(OutDir)\Microsoft.MobileBlazorBindings.WebView.iOS.dll">
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
   </ItemGroup>
 
   <!-- See comment at top of file about manually importing SDK -->

--- a/src/Microsoft.MobileBlazorBindings.WebView.macOS/Microsoft.MobileBlazorBindings.WebView.macOS.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.macOS/Microsoft.MobileBlazorBindings.WebView.macOS.csproj
@@ -46,8 +46,4 @@
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView.macOS/Microsoft.MobileBlazorBindings.WebView.macOS.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView.macOS/Microsoft.MobileBlazorBindings.WebView.macOS.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <Reference Include="netstandard" />
 
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -45,5 +45,9 @@
     <FilesToSign Include="$(OutDir)\Microsoft.MobileBlazorBindings.WebView.macOS.dll">
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView/Microsoft.MobileBlazorBindings.WebView.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView/Microsoft.MobileBlazorBindings.WebView.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.10" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,5 +32,9 @@
       <FilesToSign Include="$(OutDir)\Microsoft.MobileBlazorBindings.WebView.dll">
           <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings.WebView/Microsoft.MobileBlazorBindings.WebView.csproj
+++ b/src/Microsoft.MobileBlazorBindings.WebView/Microsoft.MobileBlazorBindings.WebView.csproj
@@ -33,8 +33,4 @@
           <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.MobileBlazorBindings/Microsoft.MobileBlazorBindings.csproj
+++ b/src/Microsoft.MobileBlazorBindings/Microsoft.MobileBlazorBindings.csproj
@@ -8,16 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1687" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates Most nugets in the solution to the latest versions. Notable exceptions:

- .net core 3.1 instead of .net 5. Blocked by #241 #179 
- Xamarin.Google.Android.Material. Upgrading to latest version gives an error on resource compilation.
- Xamarin.Forms.PancakeView. 2.x has been completely redesigned. None of the properties match. This requires more work I guess.