### PR TITLE
Add ShellProperties for attached properties

### DIFF
--- a/samples/ControlGallery/ControlGallery/AppShell.razor
+++ b/samples/ControlGallery/ControlGallery/AppShell.razor
@@ -7,6 +7,9 @@
                 <PlaygroundList />
             </ShellContent>
         </Tab>
+        <Tab Title="Shell Properties">
+            <ShellPropertiesPlayground />
+        </Tab>
         <Tab Title="Add/Remove">
             <ContentPage Title="Adder">
                 <StackLayout>

--- a/samples/ControlGallery/ControlGallery/Views/ShellPropertiesPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/ShellPropertiesPlayground.razor
@@ -1,0 +1,35 @@
+﻿<ContentPage Title="Shell Properties">
+    <ShellProperties NavBarIsVisible="navBarVisible"
+                     TabBarIsVisible="tabBarVisible"
+                     TitleColor="titleColor" />
+
+    <StackLayout>
+        <StackLayout Orientation="StackOrientation.Horizontal">
+            <Label Text="Enable NavBar: " />
+            <CheckBox @bind-IsChecked="navBarVisible" />
+        </StackLayout>
+        <StackLayout Orientation="StackOrientation.Horizontal">
+            <Label Text="Enable TabBar: " />
+            <CheckBox @bind-IsChecked="tabBarVisible" />
+        </StackLayout>
+        <Button Text="Change Title Color" OnClick="ChangeTitleColor" />
+    </StackLayout>
+</ContentPage>
+
+@code{
+    bool navBarVisible = true;
+    bool tabBarVisible = true;
+    Color? titleColor;
+
+    List<Color> colors = new List<Color> {
+        Color.Red,
+        Color.Green,
+        Color.Blue
+    };
+
+    void ChangeTitleColor()
+    {
+        var index = (titleColor.HasValue ? colors.IndexOf(titleColor.Value) + 1 : 0) % colors.Count;
+        titleColor = colors[index];
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseAttachedPropertiesHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseAttachedPropertiesHandler.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.MobileBlazorBindings.Core;
+using System;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public abstract class BaseAttachedPropertiesHandler : IXamarinFormsElementHandler, INonPhysicalChild
+    {
+        protected XF.BindableObject Parent { get; private set; }
+
+        public abstract void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName);
+
+        public void SetParent(object parentElement)
+        {
+            Parent = (XF.BindableObject)parentElement;
+        }
+
+        // Because this is a 'fake' element, all matters related to physical trees
+        // should be no-ops.
+        public XF.Element ElementControl => null;
+        public object TargetElement => null;
+        public int GetPhysicalSiblingIndex() => 0;
+        public bool IsParented() => false;
+        public bool IsParentedTo(XF.Element parent) => false;
+
+        public void SetParent(XF.Element parent)
+        {
+            // This should never get called. Instead, INonPhysicalChild.SetParent() implemented
+            // in this class should get called.
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseAttachedPropertiesHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseAttachedPropertiesHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.MobileBlazorBindings.Core;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
 using System;
 using XF = Xamarin.Forms;
 
@@ -6,13 +9,16 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public abstract class BaseAttachedPropertiesHandler : IXamarinFormsElementHandler, INonPhysicalChild
     {
-        protected XF.BindableObject Parent { get; private set; }
+        /// <summary>
+        /// The target of the attached property. This will be set to the parent of the attached property container.
+        /// </summary>
+        protected XF.BindableObject Target { get; private set; }
 
         public abstract void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName);
 
         public void SetParent(object parentElement)
         {
-            Parent = (XF.BindableObject)parentElement;
+            Target = (XF.BindableObject)parentElement;
         }
 
         // Because this is a 'fake' element, all matters related to physical trees

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellPropertiesHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellPropertiesHandler.cs
@@ -1,4 +1,7 @@
-﻿using XF = Xamarin.Forms;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
@@ -9,43 +12,43 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(ShellProperties.NavBarIsVisible):
-                    XF.Shell.SetNavBarIsVisible(Parent, AttributeHelper.GetBool(attributeValue));
+                    XF.Shell.SetNavBarIsVisible(Target, AttributeHelper.GetBool(attributeValue));
                     break;
                 case nameof(ShellProperties.NavBarHasShadow):
-                    XF.Shell.SetNavBarHasShadow(Parent, AttributeHelper.GetBool(attributeValue));
+                    XF.Shell.SetNavBarHasShadow(Target, AttributeHelper.GetBool(attributeValue));
                     break;
                 case nameof(ShellProperties.TabBarIsVisible):
-                    XF.Shell.SetTabBarIsVisible(Parent, AttributeHelper.GetBool(attributeValue));
+                    XF.Shell.SetTabBarIsVisible(Target, AttributeHelper.GetBool(attributeValue));
                     break;
                 case nameof(ShellProperties.BackgroundColor):
-                    XF.Shell.SetBackgroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetBackgroundColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.DisabledColor):
-                    XF.Shell.SetDisabledColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetDisabledColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.ForegroundColor):
-                    XF.Shell.SetForegroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetForegroundColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.TabBarBackgroundColor):
-                    XF.Shell.SetTabBarBackgroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetTabBarBackgroundColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.TabBarDisabledColor):
-                    XF.Shell.SetTabBarDisabledColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetTabBarDisabledColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.TabBarForegroundColor):
-                    XF.Shell.SetTabBarForegroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetTabBarForegroundColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.TabBarTitleColor):
-                    XF.Shell.SetTabBarTitleColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetTabBarTitleColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.TabBarUnselectedColor):
-                    XF.Shell.SetTabBarUnselectedColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetTabBarUnselectedColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.TitleColor):
-                    XF.Shell.SetTitleColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetTitleColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
                 case nameof(ShellProperties.UnselectedColor):
-                    XF.Shell.SetUnselectedColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    XF.Shell.SetUnselectedColor(Target, AttributeHelper.StringToColor(attributeValue));
                     break;
             }
         }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellPropertiesHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellPropertiesHandler.cs
@@ -1,0 +1,53 @@
+﻿using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    public class ShellPropertiesHandler : BaseAttachedPropertiesHandler
+    {
+        public override void ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName)
+        {
+            switch (attributeName)
+            {
+                case nameof(ShellProperties.NavBarIsVisible):
+                    XF.Shell.SetNavBarIsVisible(Parent, AttributeHelper.GetBool(attributeValue));
+                    break;
+                case nameof(ShellProperties.NavBarHasShadow):
+                    XF.Shell.SetNavBarHasShadow(Parent, AttributeHelper.GetBool(attributeValue));
+                    break;
+                case nameof(ShellProperties.TabBarIsVisible):
+                    XF.Shell.SetTabBarIsVisible(Parent, AttributeHelper.GetBool(attributeValue));
+                    break;
+                case nameof(ShellProperties.BackgroundColor):
+                    XF.Shell.SetBackgroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.DisabledColor):
+                    XF.Shell.SetDisabledColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.ForegroundColor):
+                    XF.Shell.SetForegroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.TabBarBackgroundColor):
+                    XF.Shell.SetTabBarBackgroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.TabBarDisabledColor):
+                    XF.Shell.SetTabBarDisabledColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.TabBarForegroundColor):
+                    XF.Shell.SetTabBarForegroundColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.TabBarTitleColor):
+                    XF.Shell.SetTabBarTitleColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.TabBarUnselectedColor):
+                    XF.Shell.SetTabBarUnselectedColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.TitleColor):
+                    XF.Shell.SetTitleColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+                case nameof(ShellProperties.UnselectedColor):
+                    XF.Shell.SetUnselectedColor(Parent, AttributeHelper.StringToColor(attributeValue));
+                    break;
+            }
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellProperties.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellProperties.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.MobileBlazorBindings.Core;
+using Microsoft.MobileBlazorBindings.Elements.Handlers;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements
+{
+    public class ShellProperties : NativeControlComponentBase
+    {
+        [Parameter] public bool? NavBarIsVisible { get; set; }
+        [Parameter] public bool? NavBarHasShadow { get; set; }
+        [Parameter] public bool? TabBarIsVisible { get; set; }
+        [Parameter] public XF.Color? BackgroundColor { get; set; }
+        [Parameter] public XF.Color? DisabledColor { get; set; }
+        [Parameter] public XF.Color? ForegroundColor { get; set; }
+        [Parameter] public XF.Color? TabBarBackgroundColor { get; set; }
+        [Parameter] public XF.Color? TabBarDisabledColor { get; set; }
+        [Parameter] public XF.Color? TabBarForegroundColor { get; set; }
+        [Parameter] public XF.Color? TabBarTitleColor { get; set; }
+        [Parameter] public XF.Color? TabBarUnselectedColor { get; set; }
+        [Parameter] public XF.Color? TitleColor { get; set; }
+        [Parameter] public XF.Color? UnselectedColor { get; set; }
+
+        static ShellProperties()
+        {
+            ElementHandlerRegistry
+                .RegisterElementHandler<ShellProperties>(_ => new ShellPropertiesHandler());
+        }
+
+        protected override void RenderAttributes(AttributesBuilder builder)
+        {
+            if (NavBarIsVisible.HasValue)
+                builder.AddAttribute(nameof(NavBarIsVisible), NavBarIsVisible.Value);
+
+            if (NavBarHasShadow.HasValue)
+                builder.AddAttribute(nameof(NavBarHasShadow), NavBarHasShadow.Value);
+
+            if (TabBarIsVisible.HasValue)
+                builder.AddAttribute(nameof(TabBarIsVisible), TabBarIsVisible.Value);
+
+            if (BackgroundColor.HasValue)
+                builder.AddAttribute(nameof(BackgroundColor), AttributeHelper.ColorToString(BackgroundColor.Value));
+
+            if (DisabledColor.HasValue)
+                builder.AddAttribute(nameof(DisabledColor), AttributeHelper.ColorToString(DisabledColor.Value));
+
+            if (ForegroundColor.HasValue)
+                builder.AddAttribute(nameof(ForegroundColor), AttributeHelper.ColorToString(ForegroundColor.Value));
+
+            if (TabBarBackgroundColor.HasValue)
+                builder.AddAttribute(nameof(TabBarBackgroundColor), AttributeHelper.ColorToString(TabBarBackgroundColor.Value));
+
+            if (TabBarDisabledColor.HasValue)
+                builder.AddAttribute(nameof(TabBarDisabledColor), AttributeHelper.ColorToString(TabBarDisabledColor.Value));
+
+            if (TabBarForegroundColor.HasValue)
+                builder.AddAttribute(nameof(TabBarForegroundColor), AttributeHelper.ColorToString(TabBarForegroundColor.Value));
+
+            if (TabBarTitleColor.HasValue)
+                builder.AddAttribute(nameof(TabBarTitleColor), AttributeHelper.ColorToString(TabBarTitleColor.Value));
+
+            if (TabBarUnselectedColor.HasValue)
+                builder.AddAttribute(nameof(TabBarUnselectedColor), AttributeHelper.ColorToString(TabBarUnselectedColor.Value));
+
+            if (TitleColor.HasValue)
+                builder.AddAttribute(nameof(TitleColor), AttributeHelper.ColorToString(TitleColor.Value));
+
+            if (UnselectedColor.HasValue)
+                builder.AddAttribute(nameof(UnselectedColor), AttributeHelper.ColorToString(UnselectedColor.Value));
+        }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/Elements/ShellProperties.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/ShellProperties.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AspNetCore.Components;
 using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.MobileBlazorBindings.Elements.Handlers;
 using XF = Xamarin.Forms;
@@ -30,43 +33,57 @@ namespace Microsoft.MobileBlazorBindings.Elements
         protected override void RenderAttributes(AttributesBuilder builder)
         {
             if (NavBarIsVisible.HasValue)
+            {
                 builder.AddAttribute(nameof(NavBarIsVisible), NavBarIsVisible.Value);
-
+            }
             if (NavBarHasShadow.HasValue)
+            {
                 builder.AddAttribute(nameof(NavBarHasShadow), NavBarHasShadow.Value);
-
+            }
             if (TabBarIsVisible.HasValue)
+            {
                 builder.AddAttribute(nameof(TabBarIsVisible), TabBarIsVisible.Value);
-
+            }
             if (BackgroundColor.HasValue)
+            {
                 builder.AddAttribute(nameof(BackgroundColor), AttributeHelper.ColorToString(BackgroundColor.Value));
-
+            }
             if (DisabledColor.HasValue)
+            {
                 builder.AddAttribute(nameof(DisabledColor), AttributeHelper.ColorToString(DisabledColor.Value));
-
+            }
             if (ForegroundColor.HasValue)
+            {
                 builder.AddAttribute(nameof(ForegroundColor), AttributeHelper.ColorToString(ForegroundColor.Value));
-
+            }
             if (TabBarBackgroundColor.HasValue)
+            {
                 builder.AddAttribute(nameof(TabBarBackgroundColor), AttributeHelper.ColorToString(TabBarBackgroundColor.Value));
-
+            }
             if (TabBarDisabledColor.HasValue)
+            {
                 builder.AddAttribute(nameof(TabBarDisabledColor), AttributeHelper.ColorToString(TabBarDisabledColor.Value));
-
+            }
             if (TabBarForegroundColor.HasValue)
+            {
                 builder.AddAttribute(nameof(TabBarForegroundColor), AttributeHelper.ColorToString(TabBarForegroundColor.Value));
-
+            }
             if (TabBarTitleColor.HasValue)
+            {
                 builder.AddAttribute(nameof(TabBarTitleColor), AttributeHelper.ColorToString(TabBarTitleColor.Value));
-
+            }
             if (TabBarUnselectedColor.HasValue)
+            {
                 builder.AddAttribute(nameof(TabBarUnselectedColor), AttributeHelper.ColorToString(TabBarUnselectedColor.Value));
-
+            }
             if (TitleColor.HasValue)
+            {
                 builder.AddAttribute(nameof(TitleColor), AttributeHelper.ColorToString(TitleColor.Value));
-
+            }
             if (UnselectedColor.HasValue)
+            {
                 builder.AddAttribute(nameof(UnselectedColor), AttributeHelper.ColorToString(UnselectedColor.Value));
+            }
         }
     }
 }


### PR DESCRIPTION
Contributes to #11 .

As discussed, I have added ShellProperties component with handler implementing INonPhysicalChild, which sets Shell attached properties for parent.

I've only added properties, which are currently supported by MBB, so no properties of types `Brush`/`SearchHandler`/`DataTemplate` here.

I've also added playground sample, feel free to exclude it if not needed.

<details>
<summary>Example</summary>

```razor
<ContentPage Title="Shell Properties">
    <ShellProperties NavBarIsVisible="false"
                     TabBarIsVisible="false"
                     TitleColor="Color.Red" />

    <StackLayout>
		...
    </StackLayout>
</ContentPage>
```

</details>

Fixes #254