### PR TITLE
Fix removing elements in LayoutHandler descendants

### DIFF
--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.cs
@@ -28,5 +28,17 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                 throw new InvalidOperationException($"Unknown child type {child.GetType().FullName} being added to parent element type {GetType().FullName}.");
             }
         }
+
+        public override void RemoveChild(XF.Element child)
+        {
+            if (child == TwoPaneViewControl.Pane1)
+            {
+                TwoPaneViewControl.Pane1 = null;
+            }
+            else if (child == TwoPaneViewControl.Pane2)
+            {
+                TwoPaneViewControl.Pane2 = null;
+            }
+        }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentViewHandler.cs
@@ -12,5 +12,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             var childAsView = child as XF.View;
             ContentViewControl.Content = childAsView;
         }
+
+        public override void RemoveChild(XF.Element child)
+        {
+            if (ContentViewControl.Content == child)
+            {
+                ContentViewControl.Content = null;
+            }
+        }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ScrollViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ScrollViewHandler.cs
@@ -12,5 +12,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             var childAsView = child as XF.View;
             ScrollViewControl.Content = childAsView;
         }
+
+        public override void RemoveChild(XF.Element child)
+        {
+            if (ScrollViewControl.Content == child)
+            {
+                ScrollViewControl.Content = null;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #271 .

Frame inherits ContentView, ContentView inherits Layout, but our LayoutHandler expects the control to be of Layout\<View\> type, which ContentView is not, therefore it fails with InvalidCastException.

I've added RemoveChild overrides for LayoutHandler descendants (ScrollViewHandler, TwoPaneViewHandler, ContentViewHandler) to solve this issue.