### PR TITLE
Use Page as Shell navigation target

### DIFF
--- a/samples/ControlGallery/ControlGallery/Views/CommonControls.razor
+++ b/samples/ControlGallery/ControlGallery/Views/CommonControls.razor
@@ -1,6 +1,6 @@
 ﻿@page "/commoncontrols"
 
-<ContentView>
+<ContentPage>
     <StackLayout Margin="new Thickness(20)">
 
         <Slider Minimum="0" Maximum="20" @bind-Value="SliderValue" />
@@ -14,7 +14,7 @@
             <Image Source="@(ImageSource.FromResource(isFavorite ? "ControlGallery.images.favorite.png" : "ControlGallery.images.not-favorite.png"))" />
         </StackLayout>
     </StackLayout>
-</ContentView>
+</ContentPage>
 
 @code
 {

--- a/samples/ControlGallery/ControlGallery/Views/GesturePlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/GesturePlayground.razor
@@ -1,6 +1,6 @@
 ﻿@page "/gestureplayground"
 
-<ContentView>
+<ContentPage>
     <StackLayout Margin="new Thickness(20)">
 
         <Label Text="Tap me or pan me"
@@ -17,7 +17,7 @@
         </Label>
 
     </StackLayout>
-</ContentView>
+</ContentPage>
 
 @code
 {

--- a/samples/ControlGallery/ControlGallery/Views/NavigationSource.razor
+++ b/samples/ControlGallery/ControlGallery/Views/NavigationSource.razor
@@ -1,20 +1,22 @@
 ﻿@page "/navigation"
 @inject ShellNavigationManager NavigationManager
 
-<ScrollView>
-    <StackLayout>
-        <Button Text="Navigate with no parameters" OnClick="NavigateNoParameter"></Button>
-        <Button Text="Navigate with name string" OnClick="NavigateWithName"></Button>
-        <Button Text="Navigate with name string and version int" OnClick="NavigateWithNameAndVersion"></Button>
-        <Button Text="Navigate with name, version, date" OnClick="NavigateWithNameVersionDate"></Button>
-        <Button Text="Navigate with Long" OnClick="NavigateWithLong"></Button>
-        <Button Text="Navigate with double" OnClick="NavigateWithDouble"></Button>
-        <Button Text="Navigate with float" OnClick="NavigateWithFloat"></Button>
-        <Button Text="Navigate with decimal" OnClick="NavigateWithDecimal"></Button>
-        <Button Text="Navigate with Guid" OnClick="NavigateWithGuid"></Button>
-        <Button Text="Navigate with Bool" OnClick="NavigateWithBool"></Button>
-    </StackLayout>
-</ScrollView>
+<ContentPage>
+    <ScrollView>
+        <StackLayout>
+            <Button Text="Navigate with no parameters" OnClick="NavigateNoParameter"></Button>
+            <Button Text="Navigate with name string" OnClick="NavigateWithName"></Button>
+            <Button Text="Navigate with name string and version int" OnClick="NavigateWithNameAndVersion"></Button>
+            <Button Text="Navigate with name, version, date" OnClick="NavigateWithNameVersionDate"></Button>
+            <Button Text="Navigate with Long" OnClick="NavigateWithLong"></Button>
+            <Button Text="Navigate with double" OnClick="NavigateWithDouble"></Button>
+            <Button Text="Navigate with float" OnClick="NavigateWithFloat"></Button>
+            <Button Text="Navigate with decimal" OnClick="NavigateWithDecimal"></Button>
+            <Button Text="Navigate with Guid" OnClick="NavigateWithGuid"></Button>
+            <Button Text="Navigate with Bool" OnClick="NavigateWithBool"></Button>
+        </StackLayout>
+    </ScrollView>
+</ContentPage>
 
 @code
 {

--- a/samples/ControlGallery/ControlGallery/Views/NavigationTarget.razor
+++ b/samples/ControlGallery/ControlGallery/Views/NavigationTarget.razor
@@ -9,7 +9,7 @@
 @page "/guid/{Guid}"
 @page "/bool/{Bool}"
 
-<ContentView>
+<ContentPage>
     <StackLayout>
         <Label Text="Successfully navigated using Shell"></Label>
         @if (Name != null)
@@ -25,7 +25,7 @@
         <Label Text="@($"Guid = {Guid}")"></Label>
         <Label Text="@($"Bool = {Bool}")"></Label>
     </StackLayout>
-</ContentView>
+</ContentPage>
 
 @code {
 

--- a/samples/ControlGallery/ControlGallery/Views/SkiaCanvasDemo.razor
+++ b/samples/ControlGallery/ControlGallery/Views/SkiaCanvasDemo.razor
@@ -1,6 +1,6 @@
 ﻿@using Microsoft.MobileBlazorBindings.SkiaSharp
 @page "/skia/canvas"
-<ContentView>
+<ContentPage>
     <StackLayout Padding="20">
         <Slider Margin="20" ValueChanged="RotationSliderChanged" />
         <SKCanvasView @ref="CanvasView"
@@ -10,4 +10,4 @@
                       OnPaintSurface="PaintSurface2"
                       VerticalOptions="LayoutOptions.FillAndExpand" />
     </StackLayout>
-</ContentView>
+</ContentPage>

--- a/samples/ControlGallery/ControlGallery/Views/SkiaPlayground.razor
+++ b/samples/ControlGallery/ControlGallery/Views/SkiaPlayground.razor
@@ -1,13 +1,13 @@
 @page "/skia"
 @inject ShellNavigationManager NavigationManager
 
-<ContentView>
+<ContentPage>
     <StackLayout>
         <Button Text="Skia Canvas Paths" OnClick="NavigateToSkiaCanvas"></Button>
     </StackLayout>
-</ContentView>
+</ContentPage>
 
 @code
-{ 
+{
     async Task NavigateToSkiaCanvas() => await NavigationManager.NavigateToAsync("/skia/canvas");
 }

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/BearDetailPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/BearDetailPage.razor
@@ -1,6 +1,6 @@
 ﻿@page "/beardetails/{Name}"
 
-<ContentView>
+<ContentPage>
     <ScrollView>
         <StackLayout>
             <Label Text="@Bear.Name"></Label>
@@ -9,7 +9,7 @@
             <Label Text="@Bear.Details"></Label>
         </StackLayout>
     </ScrollView>
-</ContentView>
+</ContentPage>
 @code {
     Animal Bear;
 

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/CatDetailPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/CatDetailPage.razor
@@ -1,6 +1,6 @@
 ﻿@page "/catdetails/{Name}"
 
-<ContentView>
+<ContentPage>
     <ScrollView>
         <StackLayout>
             <Label Text="@Cat.Name"></Label>
@@ -9,7 +9,7 @@
             <Label Text="@Cat.Details"></Label>
         </StackLayout>
     </ScrollView>
-</ContentView>
+</ContentPage>
 @code {
     Animal Cat;
 

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/DogDetailPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/DogDetailPage.razor
@@ -1,6 +1,6 @@
 ﻿@page "/dogdetails/{Name}"
 
-<ContentView>
+<ContentPage>
     <ScrollView>
         <StackLayout>
             <Label Text="@Dog.Name"></Label>
@@ -9,7 +9,7 @@
             <Label Text="@Dog.Details"></Label>
         </StackLayout>
     </ScrollView>
-</ContentView>
+</ContentPage>
 @code {
     Animal Dog;
 

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/ElephantDetailPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/ElephantDetailPage.razor
@@ -1,6 +1,6 @@
 ﻿@page "/elephantdetails/{Name}"
 
-<ContentView>
+<ContentPage>
     <ScrollView>
         <StackLayout>
             <Label Text="@Elephant.Name"></Label>
@@ -9,7 +9,7 @@
             <Label Text="@Elephant.Details"></Label>
         </StackLayout>
     </ScrollView>
-</ContentView>
+</ContentPage>
 @code {
     Animal Elephant;
 

--- a/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/MonkeyDetailPage.razor
+++ b/samples/MobileBlazorBindingsXaminals/MobileBlazorBindingsXaminals/Views/MonkeyDetailPage.razor
@@ -1,6 +1,6 @@
 ﻿@page "/monkeydetails/{Name}"
 
-<ContentView>
+<ContentPage>
     <ScrollView>
         <StackLayout>
             <Label Text="@Monkey.Name"></Label>
@@ -9,7 +9,7 @@
             <Label Text="@Monkey.Details"></Label>
         </StackLayout>
     </ScrollView>
-</ContentView>
+</ContentPage>
 @code {
     Animal Monkey;
 

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/RootContainerHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/RootContainerHandler.cs
@@ -9,8 +9,8 @@ using XF = Xamarin.Forms;
 namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     /// <summary>
-    /// Fake element handler, which is used as a root for a renderer to get native Xamarin elements
-    /// from Blazor component.
+    /// Fake element handler, which is used as a root for a renderer to get native Xamarin.Forms elements
+    /// from a Blazor component.
     /// </summary>
     public class RootContainerHandler : IXamarinFormsContainerElementHandler
     {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/RootContainerHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/RootContainerHandler.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.MobileBlazorBindings.Core;
+using System;
+using System.Collections.Generic;
+using XF = Xamarin.Forms;
+
+namespace Microsoft.MobileBlazorBindings.Elements.Handlers
+{
+    /// <summary>
+    /// Fake element handler, which is used as a root for a renderer to get native Xamarin elements
+    /// from Blazor component.
+    /// </summary>
+    public class RootContainerHandler : IXamarinFormsContainerElementHandler
+    {
+        public List<XF.Element> Elements { get; } = new List<XF.Element>();
+
+        void IXamarinFormsContainerElementHandler.AddChild(XF.Element child, int physicalSiblingIndex)
+        {
+            var index = Math.Min(physicalSiblingIndex, Elements.Count);
+            Elements.Insert(index, child);
+        }
+
+        void IXamarinFormsContainerElementHandler.RemoveChild(XF.Element child)
+        {
+            Elements.Remove(child);
+        }
+
+        int IXamarinFormsContainerElementHandler.GetChildIndex(XF.Element child)
+        {
+            return Elements.IndexOf(child);
+        }
+
+        bool IXamarinFormsElementHandler.IsParentedTo(XF.Element parent)
+        {
+            return Elements.Contains(parent);
+        }
+
+        // Because this is a 'fake' container element, all matters related to physical trees
+        // should be no-ops.
+        XF.Element IXamarinFormsElementHandler.ElementControl => null;
+        object IElementHandler.TargetElement => null;
+        void IElementHandler.ApplyAttribute(ulong attributeEventHandlerId, string attributeName, object attributeValue, string attributeEventUpdatesAttributeName) { }
+        bool IXamarinFormsElementHandler.IsParented() => false;
+        void IXamarinFormsElementHandler.SetParent(XF.Element parent) { }
+    }
+}

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHost.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHost.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.IO;
@@ -59,6 +60,11 @@ namespace Microsoft.MobileBlazorBindings
             });
 
             EnableStyleSheetSupport();
+
+            builder.ConfigureServices(serviceCollection =>
+            {
+                serviceCollection.AddSingleton<MobileBlazorBindingsRenderer>();
+            });
 
             return builder;
         }

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHostExtensions.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHostExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.MobileBlazorBindings.Elements.Handlers;
 using System;
 using System.Threading.Tasks;
@@ -66,9 +65,7 @@ namespace Microsoft.MobileBlazorBindings
                 throw new InvalidOperationException($"Cannot add {type.Name} to {parent.GetType().Name}. {type.Name} is not an IComponent. If you are trying to add a Xamarin.Forms type, try adding the Mobile Blazor Bindings equivalent instead.");
             }
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            var renderer = new MobileBlazorBindingsRenderer(services, services.GetRequiredService<ILoggerFactory>());
-#pragma warning restore CA2000 // Dispose objects before losing scope
+            var renderer = services.GetRequiredService<MobileBlazorBindingsRenderer>();
 
             return await renderer.AddComponent(type, CreateHandler(parent, renderer), parameters).ConfigureAwait(false);
         }

--- a/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHostExtensions.cs
+++ b/src/Microsoft.MobileBlazorBindings/MobileBlazorBindingsHostExtensions.cs
@@ -33,10 +33,7 @@ namespace Microsoft.MobileBlazorBindings
             }
 
             var services = host.Services;
-
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            var renderer = new MobileBlazorBindingsRenderer(services, services.GetRequiredService<ILoggerFactory>());
-#pragma warning restore CA2000 // Dispose objects before losing scope
+            var renderer = services.GetRequiredService<MobileBlazorBindingsRenderer>();
 
             // TODO: This call is an async call, but is called as "fire-and-forget," which is not ideal.
             // We need to figure out how to get Xamarin.Forms to run this startup code asynchronously, which

--- a/src/Microsoft.MobileBlazorBindings/ShellNavigation/MBBRouteFactory.cs
+++ b/src/Microsoft.MobileBlazorBindings/ShellNavigation/MBBRouteFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Threading.Tasks;
 using XF = Xamarin.Forms;
 
 
@@ -12,6 +13,7 @@ namespace Microsoft.MobileBlazorBindings.ShellNavigation
     {
         private readonly Type _type;
         private readonly ShellNavigationManager _navigationManager;
+        private XF.Element _element;
 
         public MBBRouteFactory(Type type, ShellNavigationManager navigationManager)
         {
@@ -21,7 +23,13 @@ namespace Microsoft.MobileBlazorBindings.ShellNavigation
 
         public override XF.Element GetOrCreate()
         {
-            return _navigationManager.BuildPage(_type);// new XF.ContentPage();
+            return _element
+                ?? throw new InvalidOperationException("Element is supposed to be created at this point.");
+        }
+
+        public async Task CreateAsync()
+        {
+            _element = await _navigationManager.BuildPage(_type).ConfigureAwait(false);
         }
 
         public override bool Equals(object obj)

--- a/src/Microsoft.MobileBlazorBindings/ShellNavigation/MBBRouteFactory.cs
+++ b/src/Microsoft.MobileBlazorBindings/ShellNavigation/MBBRouteFactory.cs
@@ -5,38 +5,37 @@ using System;
 using System.Threading.Tasks;
 using XF = Xamarin.Forms;
 
-
 namespace Microsoft.MobileBlazorBindings.ShellNavigation
 {
     //Based on the forms TypeRouteFactory https://github.com/xamarin/Xamarin.Forms/blob/9fd882e6c598a51bffbbb2f4de72c3bd9023ab41/Xamarin.Forms.Core/Routing.cs
     public class MBBRouteFactory : XF.RouteFactory
     {
-        private readonly Type _type;
+        private readonly Type _componentType;
         private readonly ShellNavigationManager _navigationManager;
         private XF.Element _element;
 
-        public MBBRouteFactory(Type type, ShellNavigationManager navigationManager)
+        public MBBRouteFactory(Type componentType, ShellNavigationManager navigationManager)
         {
-            _type = type;
-            _navigationManager = navigationManager;
+            _componentType = componentType ?? throw new ArgumentNullException(nameof(componentType));
+            _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
         }
 
         public override XF.Element GetOrCreate()
         {
             return _element
-                ?? throw new InvalidOperationException("Element is supposed to be created at this point.");
+                ?? throw new InvalidOperationException("The target element of the Shell navigation is supposed to be created at this point.");
         }
 
         public async Task CreateAsync()
         {
-            _element = await _navigationManager.BuildPage(_type).ConfigureAwait(false);
+            _element = await _navigationManager.BuildPage(_componentType).ConfigureAwait(false);
         }
 
         public override bool Equals(object obj)
         {
-            if ((obj is MBBRouteFactory routeFactory))
+            if ((obj is MBBRouteFactory otherRouteFactory))
             {
-                return routeFactory._type == _type;
+                return otherRouteFactory._componentType == _componentType;
             }
 
             return false;
@@ -44,7 +43,7 @@ namespace Microsoft.MobileBlazorBindings.ShellNavigation
 
         public override int GetHashCode()
         {
-            return _type.GetHashCode();
+            return _componentType.GetHashCode();
         }
     }
 }

--- a/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
+++ b/src/Microsoft.MobileBlazorBindings/ShellNavigation/ShellNavigationManager.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Xamarin.Forms;
 using XF = Xamarin.Forms;
 
 namespace Microsoft.MobileBlazorBindings
@@ -46,7 +45,7 @@ namespace Microsoft.MobileBlazorBindings
 
                         //Register with XamarinForms so it can handle Navigation.
                         var routeFactory = new MBBRouteFactory(page, this);
-                        Routing.RegisterRoute(structuredRoute.BaseUri, routeFactory);
+                        XF.Routing.RegisterRoute(structuredRoute.BaseUri, routeFactory);
 
                         //Also register route in our own list for setting parameters and tracking if it is registered;
                         Routes.Add(structuredRoute);
@@ -83,7 +82,7 @@ namespace Microsoft.MobileBlazorBindings
                 NavigationParameters[route.Route.Type] = route;
                 var routeFactory = RouteFactories[route.Route.BaseUri];
                 await routeFactory.CreateAsync().ConfigureAwait(true);
-                await Shell.Current.GoToAsync(route.Route.BaseUri).ConfigureAwait(false);
+                await XF.Shell.Current.GoToAsync(route.Route.BaseUri).ConfigureAwait(false);
             }
             else
             {
@@ -99,14 +98,14 @@ namespace Microsoft.MobileBlazorBindings
 
             await renderer.AddComponent(type, container, route.Parameters).ConfigureAwait(false);
 
-            if (container.Elements.Count > 1)
+            if (container.Elements.Count != 1)
             {
-                throw new InvalidOperationException("Navigation target component is not allowed to have more than one root element.");
+                throw new InvalidOperationException("The target component of a Shell navigation must have exactly one root element.");
             }
 
             var page = container.Elements.FirstOrDefault() as XF.Page;
 
-            return page ?? throw new InvalidOperationException("Navigation target componenent should have Page root element.");
+            return page ?? throw new InvalidOperationException("The target component of a Shell navigation must derive from the Page component.");
         }
     }
 }


### PR DESCRIPTION
Contributes to #157.

This PR allows you to have Page (e.g. ContentPage, TabbedPage...) root element as navigation target (currently you need to have ContentView).

It was resolved in a bit hacky way.
- Added fake RootContainerHandler to use it as a root for renderer. It allows to retrieve rendered ContentPage native element.
- XF.RouteFactory's GetOrCreate method is sync, and that doesn't allow to use async rendering inside. As a workaround, I've added async method CreateAsync to MbbRouteFactory, which is called _before_ Shell navigation invoked, and GetOrCreate method simply returns already created element.
- Previously ShellNavigationManager created separate MobileBlazorBindingsRenderer on each navigation. I'm not sure that's OK, so I registered MobileBlazorBindingsRenderer as a singletone. Let me know if you have any concerns.

See detailed discussion here:
https://github.com/xamarin/MobileBlazorBindings/issues/157#issuecomment-750587312


Note that this is a breaking change, you won't be able to use ContentView as navigation target root anymore.
We can add a workaround to preserve backward compatibility (wrap non-Page result in ContentPage), but I'm not sure if we should.

Fixes #298