### PR TITLE
Expose starting and finished load events

### DIFF
--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/WebViewHandler.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/WebViewHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using Microsoft.MobileBlazorBindings.Core;
 using Microsoft.MobileBlazorBindings.WebView.Elements;
 using XF = Xamarin.Forms;
@@ -41,6 +42,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                     break;
                 case nameof(XF.UrlWebViewSource):
                     Control.Source = new XF.UrlWebViewSource { Url = (string)attributeValue };
+                    break;
+                case "OnNavigationStarting":
+                    Control.OnNavigationStarting += (EventHandler<Uri>)attributeValue;
+                    break;
+                case "OnNavigationFinished":
+                    Control.OnNavigationFinished += (EventHandler<Uri>)attributeValue;
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/WebView.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/WebView.cs
@@ -23,6 +23,8 @@ namespace Microsoft.MobileBlazorBindings.Elements
 
         [Parameter] public XF.WebViewSource Source { get; set; }
         [Parameter] public EventCallback<string> OnWebMessageReceived { get; set; }
+        [Parameter] public EventHandler<Uri> OnNavigationStarting { get; set; }
+        [Parameter] public EventHandler<Uri> OnNavigationFinished { get; set; }
 
         public void SendMessage(string message)
         {
@@ -34,7 +36,9 @@ namespace Microsoft.MobileBlazorBindings.Elements
             base.RenderAttributes(builder);
 
             builder.AddAttribute("onwebmessagereceived", EventCallback.Factory.Create<WebMessageEventArgs>(this, HandleOnWebMessageReceived));
-
+            builder.AddAttribute("OnNavigationStarting", OnNavigationStarting);
+            builder.AddAttribute("OnNavigationFinished", OnNavigationFinished);
+            
             switch (Source)
             {
                 case XF.HtmlWebViewSource htmlWebViewSource:


### PR DESCRIPTION
Exposing `OnNavigationStarting` and `OnNavigationFinished` in razor in order to execute actions on top of the base events.

Disclaimer:
the method I used is probably not the best one. Is the first time I code on such kind of project and I'm not sure about how all the stuff is working in behind scenes.

This PR is not intended to be a final approach but mostly a rise of hand about a need I have on this framework.
In then the method is acceptable, well, I'm happier :)