### PR TITLE
Update Component Generator to get default value in runtime

### DIFF
--- a/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
+++ b/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
@@ -449,6 +449,8 @@ namespace {Settings.RootNamespace}
             var componentNamespacePrefix = GetNamespacePrefix(typeToGenerate, usings);
 
             // props
+            var propsDefaultValues = GetDefaultPropertyValues(typeToGenerate, propertiesToGenerate, usings);
+
             var propertySettersBuilder = new StringBuilder();
             foreach (var prop in propertiesToGenerate)
             {
@@ -495,7 +497,7 @@ namespace {Settings.RootNamespace}
 namespace {Settings.RootNamespace}.Handlers
 {{
     public {classModifiers}partial class {componentHandlerName} : {componentHandlerBaseName}
-    {{
+    {{{propsDefaultValues}
         public {componentName}Handler(NativeComponentRenderer renderer, {componentNamespacePrefix}{componentName} {componentVarName}Control) : base(renderer, {componentVarName}Control)
         {{
             {componentName}Control = {componentVarName}Control ?? throw new ArgumentNullException(nameof({componentVarName}Control));
@@ -516,24 +518,9 @@ namespace {Settings.RootNamespace}.Handlers
         private static string GetPropertySetAttribute(PropertyInfo prop, List<UsingStatement> usings)
         {
             // Handle null values by resetting to default value
-            var resetValueParameterExpression = string.Empty;
-            var bindablePropertyForProp = GetBindablePropertyForProp(prop);
-            if (bindablePropertyForProp != null)
-            {
-                var declaredDefaultValue = bindablePropertyForProp.DefaultValue;
-                var defaultValueForType = GetDefaultValueForType(prop.PropertyType);
-                var needsCustomResetValue = declaredDefaultValue == null ? false : !declaredDefaultValue.Equals(defaultValueForType);
-
-                if (needsCustomResetValue)
-                {
-                    var valueExpression = GetValueExpression(declaredDefaultValue, usings);
-                    if (string.IsNullOrEmpty(valueExpression))
-                    {
-                        Console.WriteLine($"WARNING: Couldn't get value expression for {prop.DeclaringType.Name}.{prop.Name} of type {prop.PropertyType.FullName}.");
-                    }
-                    resetValueParameterExpression = valueExpression;
-                }
-            }
+            var resetValueParameterExpression = BindablePropertyExistsForProp(prop)
+                ? $"{prop.Name}DefaultValue"
+                : string.Empty;
 
             var formattedValue = string.Empty;
             if (TypeToAttributeHelperSetter.TryGetValue(prop.PropertyType, out var propValueFormat))
@@ -574,78 +561,43 @@ namespace {Settings.RootNamespace}.Handlers
 ";
         }
 
-        private static string GetValueExpression(object declaredDefaultValue, List<UsingStatement> usings)
+        private static string GetDefaultPropertyValues(Type type, IEnumerable<PropertyInfo> properties, IList<UsingStatement> usings)
         {
-            if (declaredDefaultValue is null)
+            var bindableProps = properties.Where(BindablePropertyExistsForProp).ToList();
+
+            if (bindableProps.Count == 0)
             {
-                throw new ArgumentNullException(nameof(declaredDefaultValue));
+                return string.Empty;
             }
 
-            return declaredDefaultValue switch
+            var stringBuilder = new StringBuilder();
+            var typeName = GetTypeNameAndAddNamespace(type, usings);
+
+            stringBuilder
+                .AppendLine()
+                .AppendLine("        #region Default values")
+                .AppendLine();
+
+            foreach (var prop in bindableProps)
             {
-                bool boolValue => boolValue ? "true" : "false",
-                int intValue => GetIntValueExpression(intValue),
-                float floatValue => floatValue.ToString("F", CultureInfo.InvariantCulture) + "f", // "Fixed-Point": https://docs.microsoft.com/dotnet/standard/base-types/standard-numeric-format-strings#the-fixed-point-f-format-specifier
-                double doubleValue => doubleValue.ToString("F", CultureInfo.InvariantCulture), // "Fixed-Point": https://docs.microsoft.com/dotnet/standard/base-types/standard-numeric-format-strings#the-fixed-point-f-format-specifier
-                Enum enumValue => GetTypeNameAndAddNamespace(enumValue.GetType(), usings) + "." + Enum.GetName(enumValue.GetType(), declaredDefaultValue),
-                XF.GridLength gridLengthValue => GetGridLengthValueExpression(gridLengthValue, usings),
-                XF.LayoutOptions layoutOptionsValue => GetLayoutOptionsValueExpression(layoutOptionsValue, usings),
-                string stringValue => $@"""{stringValue}""",
-                DateTime dateTimeValue => $"global::System.DateTime.Parse(\"{dateTimeValue.ToString("o", CultureInfo.InvariantCulture)}\", null, global::System.Globalization.DateTimeStyles.RoundtripKind)", // "Round-trip": https://docs.microsoft.com/dotnet/standard/base-types/how-to-round-trip-date-and-time-values
-                TimeSpan timeSpanValue => timeSpanValue.Ticks.ToString(CultureInfo.InvariantCulture),
-                // TODO: More types here
-                _ => null,
-            };
-        }
+                var propTypeName = GetTypeNameAndAddNamespace(prop.PropertyType, usings);
+                var propertyDefaultValue = $"{typeName}.{prop.Name}Property.DefaultValue";
 
-        private static string GetGridLengthValueExpression(XF.GridLength gridLengthValue, List<UsingStatement> usings)
-        {
-            var namespacePrefix = GetNamespacePrefix(typeof(XF.GridUnitType), usings);
-
-            return gridLengthValue.GridUnitType switch
-            {
-                XF.GridUnitType.Absolute => string.Format(CultureInfo.InvariantCulture, "new {0}GridLength({1})", namespacePrefix, gridLengthValue.Value),
-                XF.GridUnitType.Star => $"{namespacePrefix}GridLength.Star",
-                XF.GridUnitType.Auto => $"{namespacePrefix}GridLength.Auto",
-                _ => null, // TODO: Error
-            };
-        }
-
-        private static string GetLayoutOptionsValueExpression(XF.LayoutOptions layoutOptionsValue, List<UsingStatement> usings)
-        {
-            var namespacePrefix = GetNamespacePrefix(typeof(XF.GridUnitType), usings);
-
-            var expandSuffix = layoutOptionsValue.Expands ? "AndExpand" : string.Empty;
-            return $"{namespacePrefix}LayoutOptions.{layoutOptionsValue.Alignment}{expandSuffix}";
-        }
-
-        private static string GetIntValueExpression(int intValue)
-        {
-            return intValue switch
-            {
-                int.MinValue => "int.MinValue",
-                int.MaxValue => "int.MaxValue",
-                _ => intValue.ToString(CultureInfo.InvariantCulture),
-            };
-        }
-
-        private static object GetDefaultValueForType(Type propertyType)
-        {
-            if (propertyType.IsValueType)
-            {
-                return Activator.CreateInstance(propertyType);
+                stringBuilder.AppendLine($"        private static readonly {propTypeName} {prop.Name}DefaultValue = " +
+                    $"{propertyDefaultValue} is {propTypeName} value ? value : default;");
             }
-            return null;
+
+            stringBuilder
+                .AppendLine()
+                .AppendLine("        #endregion Default values");
+
+            return stringBuilder.ToString();
         }
 
-        private static XF.BindableProperty GetBindablePropertyForProp(PropertyInfo prop)
+        private static bool BindablePropertyExistsForProp(PropertyInfo prop)
         {
             var bindablePropertyField = prop.DeclaringType.GetField(prop.Name + "Property");
-            if (bindablePropertyField == null)
-            {
-                return null;
-            }
-            return (XF.BindableProperty)bindablePropertyField.GetValue(null);
+            return bindablePropertyField != null;
         }
 
         private static readonly Dictionary<Type, string> TypeToAttributeHelperSetter = new Dictionary<Type, string>

--- a/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
+++ b/src/ComponentWrapperGenerator/ComponentWrapperGenerator.cs
@@ -497,7 +497,8 @@ namespace {Settings.RootNamespace}
 namespace {Settings.RootNamespace}.Handlers
 {{
     public {classModifiers}partial class {componentHandlerName} : {componentHandlerBaseName}
-    {{{propsDefaultValues}
+    {{
+{propsDefaultValues}
         public {componentName}Handler(NativeComponentRenderer renderer, {componentNamespacePrefix}{componentName} {componentVarName}Control) : base(renderer, {componentVarName}Control)
         {{
             {componentName}Control = {componentVarName}Control ?? throw new ArgumentNullException(nameof({componentVarName}Control));
@@ -573,11 +574,6 @@ namespace {Settings.RootNamespace}.Handlers
             var stringBuilder = new StringBuilder();
             var typeName = GetTypeNameAndAddNamespace(type, usings);
 
-            stringBuilder
-                .AppendLine()
-                .AppendLine("        #region Default values")
-                .AppendLine();
-
             foreach (var prop in bindableProps)
             {
                 var propTypeName = GetTypeNameAndAddNamespace(prop.PropertyType, usings);
@@ -586,10 +582,6 @@ namespace {Settings.RootNamespace}.Handlers
                 stringBuilder.AppendLine($"        private static readonly {propTypeName} {prop.Name}DefaultValue = " +
                     $"{propertyDefaultValue} is {propTypeName} value ? value : default;");
             }
-
-            stringBuilder
-                .AppendLine()
-                .AppendLine("        #endregion Default values");
 
             return stringBuilder.ToString();
         }

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.generated.cs
@@ -10,6 +10,18 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TwoPaneViewHandler : GridHandler
     {
+        #region Default values
+
+        private static readonly double MinTallModeHeightDefaultValue = XFD.TwoPaneView.MinTallModeHeightProperty.DefaultValue is double value ? value : default;
+        private static readonly double MinWideModeWidthDefaultValue = XFD.TwoPaneView.MinWideModeWidthProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.GridLength Pane1LengthDefaultValue = XFD.TwoPaneView.Pane1LengthProperty.DefaultValue is XF.GridLength value ? value : default;
+        private static readonly XF.GridLength Pane2LengthDefaultValue = XFD.TwoPaneView.Pane2LengthProperty.DefaultValue is XF.GridLength value ? value : default;
+        private static readonly XFD.TwoPaneViewPriority PanePriorityDefaultValue = XFD.TwoPaneView.PanePriorityProperty.DefaultValue is XFD.TwoPaneViewPriority value ? value : default;
+        private static readonly XFD.TwoPaneViewTallModeConfiguration TallModeConfigurationDefaultValue = XFD.TwoPaneView.TallModeConfigurationProperty.DefaultValue is XFD.TwoPaneViewTallModeConfiguration value ? value : default;
+        private static readonly XFD.TwoPaneViewWideModeConfiguration WideModeConfigurationDefaultValue = XFD.TwoPaneView.WideModeConfigurationProperty.DefaultValue is XFD.TwoPaneViewWideModeConfiguration value ? value : default;
+        
+        #endregion Default values
+
         public TwoPaneViewHandler(NativeComponentRenderer renderer, XFD.TwoPaneView twoPaneViewControl) : base(renderer, twoPaneViewControl)
         {
             TwoPaneViewControl = twoPaneViewControl ?? throw new ArgumentNullException(nameof(twoPaneViewControl));
@@ -26,25 +38,25 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XFD.TwoPaneView.MinTallModeHeight):
-                    TwoPaneViewControl.MinTallModeHeight = AttributeHelper.StringToDouble((string)attributeValue);
+                    TwoPaneViewControl.MinTallModeHeight = AttributeHelper.StringToDouble((string)attributeValue, MinTallModeHeightDefaultValue);
                     break;
                 case nameof(XFD.TwoPaneView.MinWideModeWidth):
-                    TwoPaneViewControl.MinWideModeWidth = AttributeHelper.StringToDouble((string)attributeValue);
+                    TwoPaneViewControl.MinWideModeWidth = AttributeHelper.StringToDouble((string)attributeValue, MinWideModeWidthDefaultValue);
                     break;
                 case nameof(XFD.TwoPaneView.Pane1Length):
-                    TwoPaneViewControl.Pane1Length = AttributeHelper.StringToGridLength(attributeValue, XF.GridLength.Star);
+                    TwoPaneViewControl.Pane1Length = AttributeHelper.StringToGridLength(attributeValue, Pane1LengthDefaultValue);
                     break;
                 case nameof(XFD.TwoPaneView.Pane2Length):
-                    TwoPaneViewControl.Pane2Length = AttributeHelper.StringToGridLength(attributeValue, XF.GridLength.Star);
+                    TwoPaneViewControl.Pane2Length = AttributeHelper.StringToGridLength(attributeValue, Pane2LengthDefaultValue);
                     break;
                 case nameof(XFD.TwoPaneView.PanePriority):
-                    TwoPaneViewControl.PanePriority = (XFD.TwoPaneViewPriority)AttributeHelper.GetInt(attributeValue);
+                    TwoPaneViewControl.PanePriority = (XFD.TwoPaneViewPriority)AttributeHelper.GetInt(attributeValue, (int)PanePriorityDefaultValue);
                     break;
                 case nameof(XFD.TwoPaneView.TallModeConfiguration):
-                    TwoPaneViewControl.TallModeConfiguration = (XFD.TwoPaneViewTallModeConfiguration)AttributeHelper.GetInt(attributeValue, (int)XFD.TwoPaneViewTallModeConfiguration.TopBottom);
+                    TwoPaneViewControl.TallModeConfiguration = (XFD.TwoPaneViewTallModeConfiguration)AttributeHelper.GetInt(attributeValue, (int)TallModeConfigurationDefaultValue);
                     break;
                 case nameof(XFD.TwoPaneView.WideModeConfiguration):
-                    TwoPaneViewControl.WideModeConfiguration = (XFD.TwoPaneViewWideModeConfiguration)AttributeHelper.GetInt(attributeValue, (int)XFD.TwoPaneViewWideModeConfiguration.LeftRight);
+                    TwoPaneViewControl.WideModeConfiguration = (XFD.TwoPaneViewWideModeConfiguration)AttributeHelper.GetInt(attributeValue, (int)WideModeConfigurationDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings.DualScreen/Elements/Handlers/TwoPaneViewHandler.generated.cs
@@ -10,8 +10,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TwoPaneViewHandler : GridHandler
     {
-        #region Default values
-
         private static readonly double MinTallModeHeightDefaultValue = XFD.TwoPaneView.MinTallModeHeightProperty.DefaultValue is double value ? value : default;
         private static readonly double MinWideModeWidthDefaultValue = XFD.TwoPaneView.MinWideModeWidthProperty.DefaultValue is double value ? value : default;
         private static readonly XF.GridLength Pane1LengthDefaultValue = XFD.TwoPaneView.Pane1LengthProperty.DefaultValue is XF.GridLength value ? value : default;
@@ -19,8 +17,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly XFD.TwoPaneViewPriority PanePriorityDefaultValue = XFD.TwoPaneView.PanePriorityProperty.DefaultValue is XFD.TwoPaneViewPriority value ? value : default;
         private static readonly XFD.TwoPaneViewTallModeConfiguration TallModeConfigurationDefaultValue = XFD.TwoPaneView.TallModeConfigurationProperty.DefaultValue is XFD.TwoPaneViewTallModeConfiguration value ? value : default;
         private static readonly XFD.TwoPaneViewWideModeConfiguration WideModeConfigurationDefaultValue = XFD.TwoPaneView.WideModeConfigurationProperty.DefaultValue is XFD.TwoPaneViewWideModeConfiguration value ? value : default;
-        
-        #endregion Default values
 
         public TwoPaneViewHandler(NativeComponentRenderer renderer, XFD.TwoPaneView twoPaneViewControl) : base(renderer, twoPaneViewControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/.editorconfig
+++ b/src/Microsoft.MobileBlazorBindings/.editorconfig
@@ -5,3 +5,7 @@ dotnet_diagnostic.BL0006.severity = none
 
 # CA1303: Do not pass literals as localized parameters
 dotnet_diagnostic.CA1303.severity = none
+
+[*.generated.cs]
+# CS0618: Type or member is obsolete
+dotnet_diagnostic.CS0618.severity = none

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ActivityIndicatorHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ActivityIndicatorHandler.generated.cs
@@ -9,12 +9,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ActivityIndicatorHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly XF.Color ColorDefaultValue = XF.ActivityIndicator.ColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly bool IsRunningDefaultValue = XF.ActivityIndicator.IsRunningProperty.DefaultValue is bool value ? value : default;
-
-        #endregion Default values
 
         public ActivityIndicatorHandler(NativeComponentRenderer renderer, XF.ActivityIndicator activityIndicatorControl) : base(renderer, activityIndicatorControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ActivityIndicatorHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ActivityIndicatorHandler.generated.cs
@@ -9,6 +9,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ActivityIndicatorHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly XF.Color ColorDefaultValue = XF.ActivityIndicator.ColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly bool IsRunningDefaultValue = XF.ActivityIndicator.IsRunningProperty.DefaultValue is bool value ? value : default;
+
+        #endregion Default values
+
         public ActivityIndicatorHandler(NativeComponentRenderer renderer, XF.ActivityIndicator activityIndicatorControl) : base(renderer, activityIndicatorControl)
         {
             ActivityIndicatorControl = activityIndicatorControl ?? throw new ArgumentNullException(nameof(activityIndicatorControl));
@@ -25,10 +32,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.ActivityIndicator.Color):
-                    ActivityIndicatorControl.Color = AttributeHelper.StringToColor((string)attributeValue);
+                    ActivityIndicatorControl.Color = AttributeHelper.StringToColor((string)attributeValue, ColorDefaultValue);
                     break;
                 case nameof(XF.ActivityIndicator.IsRunning):
-                    ActivityIndicatorControl.IsRunning = AttributeHelper.GetBool(attributeValue);
+                    ActivityIndicatorControl.IsRunning = AttributeHelper.GetBool(attributeValue, IsRunningDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseMenuItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseMenuItemHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public abstract partial class BaseMenuItemHandler : ElementHandler
     {
+
         public BaseMenuItemHandler(NativeComponentRenderer renderer, XF.BaseMenuItem baseMenuItemControl) : base(renderer, baseMenuItemControl)
         {
             BaseMenuItemControl = baseMenuItemControl ?? throw new ArgumentNullException(nameof(baseMenuItemControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.generated.cs
@@ -9,6 +9,18 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class BaseShellItemHandler : NavigableElementHandler
     {
+        #region Default values
+
+        private static readonly XF.ImageSource FlyoutIconDefaultValue = XF.BaseShellItem.FlyoutIconProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly XF.ImageSource IconDefaultValue = XF.BaseShellItem.IconProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly bool IsEnabledDefaultValue = XF.BaseShellItem.IsEnabledProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsTabStopDefaultValue = XF.BaseShellItem.IsTabStopProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsVisibleDefaultValue = XF.BaseShellItem.IsVisibleProperty.DefaultValue is bool value ? value : default;
+        private static readonly int TabIndexDefaultValue = XF.BaseShellItem.TabIndexProperty.DefaultValue is int value ? value : default;
+        private static readonly string TitleDefaultValue = XF.BaseShellItem.TitleProperty.DefaultValue is string value ? value : default;
+
+        #endregion Default values
+
         public BaseShellItemHandler(NativeComponentRenderer renderer, XF.BaseShellItem baseShellItemControl) : base(renderer, baseShellItemControl)
         {
             BaseShellItemControl = baseShellItemControl ?? throw new ArgumentNullException(nameof(baseShellItemControl));
@@ -25,31 +37,31 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.BaseShellItem.FlyoutIcon):
-                    BaseShellItemControl.FlyoutIcon = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    BaseShellItemControl.FlyoutIcon = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, FlyoutIconDefaultValue);
                     break;
                 case nameof(XF.BaseShellItem.FlyoutItemIsVisible):
                     BaseShellItemControl.FlyoutItemIsVisible = AttributeHelper.GetBool(attributeValue);
                     break;
                 case nameof(XF.BaseShellItem.Icon):
-                    BaseShellItemControl.Icon = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    BaseShellItemControl.Icon = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, IconDefaultValue);
                     break;
                 case nameof(XF.BaseShellItem.IsEnabled):
-                    BaseShellItemControl.IsEnabled = AttributeHelper.GetBool(attributeValue, true);
+                    BaseShellItemControl.IsEnabled = AttributeHelper.GetBool(attributeValue, IsEnabledDefaultValue);
                     break;
                 case nameof(XF.BaseShellItem.IsTabStop):
-                    BaseShellItemControl.IsTabStop = AttributeHelper.GetBool(attributeValue, true);
+                    BaseShellItemControl.IsTabStop = AttributeHelper.GetBool(attributeValue, IsTabStopDefaultValue);
                     break;
                 case nameof(XF.BaseShellItem.IsVisible):
-                    BaseShellItemControl.IsVisible = AttributeHelper.GetBool(attributeValue, true);
+                    BaseShellItemControl.IsVisible = AttributeHelper.GetBool(attributeValue, IsVisibleDefaultValue);
                     break;
                 case nameof(XF.BaseShellItem.Route):
                     BaseShellItemControl.Route = (string)attributeValue;
                     break;
                 case nameof(XF.BaseShellItem.TabIndex):
-                    BaseShellItemControl.TabIndex = AttributeHelper.GetInt(attributeValue);
+                    BaseShellItemControl.TabIndex = AttributeHelper.GetInt(attributeValue, TabIndexDefaultValue);
                     break;
                 case nameof(XF.BaseShellItem.Title):
-                    BaseShellItemControl.Title = (string)attributeValue;
+                    BaseShellItemControl.Title = (string)attributeValue ?? TitleDefaultValue;
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BaseShellItemHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class BaseShellItemHandler : NavigableElementHandler
     {
-        #region Default values
-
         private static readonly XF.ImageSource FlyoutIconDefaultValue = XF.BaseShellItem.FlyoutIconProperty.DefaultValue is XF.ImageSource value ? value : default;
         private static readonly XF.ImageSource IconDefaultValue = XF.BaseShellItem.IconProperty.DefaultValue is XF.ImageSource value ? value : default;
         private static readonly bool IsEnabledDefaultValue = XF.BaseShellItem.IsEnabledProperty.DefaultValue is bool value ? value : default;
@@ -18,8 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly bool IsVisibleDefaultValue = XF.BaseShellItem.IsVisibleProperty.DefaultValue is bool value ? value : default;
         private static readonly int TabIndexDefaultValue = XF.BaseShellItem.TabIndexProperty.DefaultValue is int value ? value : default;
         private static readonly string TitleDefaultValue = XF.BaseShellItem.TitleProperty.DefaultValue is string value ? value : default;
-
-        #endregion Default values
 
         public BaseShellItemHandler(NativeComponentRenderer renderer, XF.BaseShellItem baseShellItemControl) : base(renderer, baseShellItemControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BoxViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BoxViewHandler.generated.cs
@@ -9,12 +9,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class BoxViewHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly XF.Color ColorDefaultValue = XF.BoxView.ColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.CornerRadius CornerRadiusDefaultValue = XF.BoxView.CornerRadiusProperty.DefaultValue is XF.CornerRadius value ? value : default;
-
-        #endregion Default values
 
         public BoxViewHandler(NativeComponentRenderer renderer, XF.BoxView boxViewControl) : base(renderer, boxViewControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BoxViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/BoxViewHandler.generated.cs
@@ -9,6 +9,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class BoxViewHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly XF.Color ColorDefaultValue = XF.BoxView.ColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.CornerRadius CornerRadiusDefaultValue = XF.BoxView.CornerRadiusProperty.DefaultValue is XF.CornerRadius value ? value : default;
+
+        #endregion Default values
+
         public BoxViewHandler(NativeComponentRenderer renderer, XF.BoxView boxViewControl) : base(renderer, boxViewControl)
         {
             BoxViewControl = boxViewControl ?? throw new ArgumentNullException(nameof(boxViewControl));
@@ -25,10 +32,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.BoxView.Color):
-                    BoxViewControl.Color = AttributeHelper.StringToColor((string)attributeValue);
+                    BoxViewControl.Color = AttributeHelper.StringToColor((string)attributeValue, ColorDefaultValue);
                     break;
                 case nameof(XF.BoxView.CornerRadius):
-                    BoxViewControl.CornerRadius = AttributeHelper.StringToCornerRadius(attributeValue);
+                    BoxViewControl.CornerRadius = AttributeHelper.StringToCornerRadius(attributeValue, CornerRadiusDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.generated.cs
@@ -9,6 +9,23 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ButtonHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly XF.Color BorderColorDefaultValue = XF.Button.BorderColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly double BorderWidthDefaultValue = XF.Button.BorderWidthProperty.DefaultValue is double value ? value : default;
+        private static readonly double CharacterSpacingDefaultValue = XF.Button.CharacterSpacingProperty.DefaultValue is double value ? value : default;
+        private static readonly int CornerRadiusDefaultValue = XF.Button.CornerRadiusProperty.DefaultValue is int value ? value : default;
+        private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.Button.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
+        private static readonly string FontFamilyDefaultValue = XF.Button.FontFamilyProperty.DefaultValue is string value ? value : default;
+        private static readonly double FontSizeDefaultValue = XF.Button.FontSizeProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.ImageSource ImageSourceDefaultValue = XF.Button.ImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly XF.Thickness PaddingDefaultValue = XF.Button.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
+        private static readonly string TextDefaultValue = XF.Button.TextProperty.DefaultValue is string value ? value : default;
+        private static readonly XF.Color TextColorDefaultValue = XF.Button.TextColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.TextTransform TextTransformDefaultValue = XF.Button.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
+
+        #endregion Default values
+
         public ButtonHandler(NativeComponentRenderer renderer, XF.Button buttonControl) : base(renderer, buttonControl)
         {
             ButtonControl = buttonControl ?? throw new ArgumentNullException(nameof(buttonControl));
@@ -25,40 +42,40 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Button.BorderColor):
-                    ButtonControl.BorderColor = AttributeHelper.StringToColor((string)attributeValue);
+                    ButtonControl.BorderColor = AttributeHelper.StringToColor((string)attributeValue, BorderColorDefaultValue);
                     break;
                 case nameof(XF.Button.BorderWidth):
-                    ButtonControl.BorderWidth = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    ButtonControl.BorderWidth = AttributeHelper.StringToDouble((string)attributeValue, BorderWidthDefaultValue);
                     break;
                 case nameof(XF.Button.CharacterSpacing):
-                    ButtonControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue);
+                    ButtonControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue, CharacterSpacingDefaultValue);
                     break;
                 case nameof(XF.Button.CornerRadius):
-                    ButtonControl.CornerRadius = AttributeHelper.GetInt(attributeValue, -1);
+                    ButtonControl.CornerRadius = AttributeHelper.GetInt(attributeValue, CornerRadiusDefaultValue);
                     break;
                 case nameof(XF.Button.FontAttributes):
-                    ButtonControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue);
+                    ButtonControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue, (int)FontAttributesDefaultValue);
                     break;
                 case nameof(XF.Button.FontFamily):
-                    ButtonControl.FontFamily = (string)attributeValue;
+                    ButtonControl.FontFamily = (string)attributeValue ?? FontFamilyDefaultValue;
                     break;
                 case nameof(XF.Button.FontSize):
-                    ButtonControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    ButtonControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, FontSizeDefaultValue);
                     break;
                 case nameof(XF.Button.ImageSource):
-                    ButtonControl.ImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    ButtonControl.ImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, ImageSourceDefaultValue);
                     break;
                 case nameof(XF.Button.Padding):
-                    ButtonControl.Padding = AttributeHelper.StringToThickness(attributeValue);
+                    ButtonControl.Padding = AttributeHelper.StringToThickness(attributeValue, PaddingDefaultValue);
                     break;
                 case nameof(XF.Button.Text):
-                    ButtonControl.Text = (string)attributeValue;
+                    ButtonControl.Text = (string)attributeValue ?? TextDefaultValue;
                     break;
                 case nameof(XF.Button.TextColor):
-                    ButtonControl.TextColor = AttributeHelper.StringToColor((string)attributeValue);
+                    ButtonControl.TextColor = AttributeHelper.StringToColor((string)attributeValue, TextColorDefaultValue);
                     break;
                 case nameof(XF.Button.TextTransform):
-                    ButtonControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)XF.TextTransform.Default);
+                    ButtonControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)TextTransformDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ButtonHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ButtonHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly XF.Color BorderColorDefaultValue = XF.Button.BorderColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly double BorderWidthDefaultValue = XF.Button.BorderWidthProperty.DefaultValue is double value ? value : default;
         private static readonly double CharacterSpacingDefaultValue = XF.Button.CharacterSpacingProperty.DefaultValue is double value ? value : default;
@@ -23,8 +21,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly string TextDefaultValue = XF.Button.TextProperty.DefaultValue is string value ? value : default;
         private static readonly XF.Color TextColorDefaultValue = XF.Button.TextColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.TextTransform TextTransformDefaultValue = XF.Button.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
-
-        #endregion Default values
 
         public ButtonHandler(NativeComponentRenderer renderer, XF.Button buttonControl) : base(renderer, buttonControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.generated.cs
@@ -9,12 +9,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class CheckBoxHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly XF.Color ColorDefaultValue = XF.CheckBox.ColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly bool IsCheckedDefaultValue = XF.CheckBox.IsCheckedProperty.DefaultValue is bool value ? value : default;
-
-        #endregion Default values
 
         public CheckBoxHandler(NativeComponentRenderer renderer, XF.CheckBox checkBoxControl) : base(renderer, checkBoxControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/CheckBoxHandler.generated.cs
@@ -9,6 +9,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class CheckBoxHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly XF.Color ColorDefaultValue = XF.CheckBox.ColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly bool IsCheckedDefaultValue = XF.CheckBox.IsCheckedProperty.DefaultValue is bool value ? value : default;
+
+        #endregion Default values
+
         public CheckBoxHandler(NativeComponentRenderer renderer, XF.CheckBox checkBoxControl) : base(renderer, checkBoxControl)
         {
             CheckBoxControl = checkBoxControl ?? throw new ArgumentNullException(nameof(checkBoxControl));
@@ -25,10 +32,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.CheckBox.Color):
-                    CheckBoxControl.Color = AttributeHelper.StringToColor((string)attributeValue);
+                    CheckBoxControl.Color = AttributeHelper.StringToColor((string)attributeValue, ColorDefaultValue);
                     break;
                 case nameof(XF.CheckBox.IsChecked):
-                    CheckBoxControl.IsChecked = AttributeHelper.GetBool(attributeValue);
+                    CheckBoxControl.IsChecked = AttributeHelper.GetBool(attributeValue, IsCheckedDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentPageHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ContentPageHandler : TemplatedPageHandler
     {
+
         public ContentPageHandler(NativeComponentRenderer renderer, XF.ContentPage contentPageControl) : base(renderer, contentPageControl)
         {
             ContentPageControl = contentPageControl ?? throw new ArgumentNullException(nameof(contentPageControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ContentViewHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ContentViewHandler : TemplatedViewHandler
     {
+
         public ContentViewHandler(NativeComponentRenderer renderer, XF.ContentView contentViewControl) : base(renderer, contentViewControl)
         {
             ContentViewControl = contentViewControl ?? throw new ArgumentNullException(nameof(contentViewControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/DatePickerHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/DatePickerHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class DatePickerHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly double CharacterSpacingDefaultValue = XF.DatePicker.CharacterSpacingProperty.DefaultValue is double value ? value : default;
         private static readonly DateTime DateDefaultValue = XF.DatePicker.DateProperty.DefaultValue is DateTime value ? value : default;
         private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.DatePicker.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
@@ -21,8 +19,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly DateTime MinimumDateDefaultValue = XF.DatePicker.MinimumDateProperty.DefaultValue is DateTime value ? value : default;
         private static readonly XF.Color TextColorDefaultValue = XF.DatePicker.TextColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.TextTransform TextTransformDefaultValue = XF.DatePicker.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
-
-        #endregion Default values
 
         public DatePickerHandler(NativeComponentRenderer renderer, XF.DatePicker datePickerControl) : base(renderer, datePickerControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/DatePickerHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/DatePickerHandler.generated.cs
@@ -9,6 +9,21 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class DatePickerHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly double CharacterSpacingDefaultValue = XF.DatePicker.CharacterSpacingProperty.DefaultValue is double value ? value : default;
+        private static readonly DateTime DateDefaultValue = XF.DatePicker.DateProperty.DefaultValue is DateTime value ? value : default;
+        private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.DatePicker.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
+        private static readonly string FontFamilyDefaultValue = XF.DatePicker.FontFamilyProperty.DefaultValue is string value ? value : default;
+        private static readonly double FontSizeDefaultValue = XF.DatePicker.FontSizeProperty.DefaultValue is double value ? value : default;
+        private static readonly string FormatDefaultValue = XF.DatePicker.FormatProperty.DefaultValue is string value ? value : default;
+        private static readonly DateTime MaximumDateDefaultValue = XF.DatePicker.MaximumDateProperty.DefaultValue is DateTime value ? value : default;
+        private static readonly DateTime MinimumDateDefaultValue = XF.DatePicker.MinimumDateProperty.DefaultValue is DateTime value ? value : default;
+        private static readonly XF.Color TextColorDefaultValue = XF.DatePicker.TextColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.TextTransform TextTransformDefaultValue = XF.DatePicker.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
+
+        #endregion Default values
+
         public DatePickerHandler(NativeComponentRenderer renderer, XF.DatePicker datePickerControl) : base(renderer, datePickerControl)
         {
             DatePickerControl = datePickerControl ?? throw new ArgumentNullException(nameof(datePickerControl));
@@ -25,34 +40,34 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.DatePicker.CharacterSpacing):
-                    DatePickerControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue);
+                    DatePickerControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue, CharacterSpacingDefaultValue);
                     break;
                 case nameof(XF.DatePicker.Date):
-                    DatePickerControl.Date = AttributeHelper.StringToDateTime(attributeValue);
+                    DatePickerControl.Date = AttributeHelper.StringToDateTime(attributeValue, DateDefaultValue);
                     break;
                 case nameof(XF.DatePicker.FontAttributes):
-                    DatePickerControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue);
+                    DatePickerControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue, (int)FontAttributesDefaultValue);
                     break;
                 case nameof(XF.DatePicker.FontFamily):
-                    DatePickerControl.FontFamily = (string)attributeValue;
+                    DatePickerControl.FontFamily = (string)attributeValue ?? FontFamilyDefaultValue;
                     break;
                 case nameof(XF.DatePicker.FontSize):
-                    DatePickerControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    DatePickerControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, FontSizeDefaultValue);
                     break;
                 case nameof(XF.DatePicker.Format):
-                    DatePickerControl.Format = (string)attributeValue ?? "d";
+                    DatePickerControl.Format = (string)attributeValue ?? FormatDefaultValue;
                     break;
                 case nameof(XF.DatePicker.MaximumDate):
-                    DatePickerControl.MaximumDate = AttributeHelper.StringToDateTime(attributeValue, global::System.DateTime.Parse("2100-12-31T00:00:00.0000000", null, global::System.Globalization.DateTimeStyles.RoundtripKind));
+                    DatePickerControl.MaximumDate = AttributeHelper.StringToDateTime(attributeValue, MaximumDateDefaultValue);
                     break;
                 case nameof(XF.DatePicker.MinimumDate):
-                    DatePickerControl.MinimumDate = AttributeHelper.StringToDateTime(attributeValue, global::System.DateTime.Parse("1900-01-01T00:00:00.0000000", null, global::System.Globalization.DateTimeStyles.RoundtripKind));
+                    DatePickerControl.MinimumDate = AttributeHelper.StringToDateTime(attributeValue, MinimumDateDefaultValue);
                     break;
                 case nameof(XF.DatePicker.TextColor):
-                    DatePickerControl.TextColor = AttributeHelper.StringToColor((string)attributeValue);
+                    DatePickerControl.TextColor = AttributeHelper.StringToColor((string)attributeValue, TextColorDefaultValue);
                     break;
                 case nameof(XF.DatePicker.TextTransform):
-                    DatePickerControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)XF.TextTransform.Default);
+                    DatePickerControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)TextTransformDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class EntryHandler : InputViewHandler
     {
-        #region Default values
-
         private static readonly XF.ClearButtonVisibility ClearButtonVisibilityDefaultValue = XF.Entry.ClearButtonVisibilityProperty.DefaultValue is XF.ClearButtonVisibility value ? value : default;
         private static readonly int CursorPositionDefaultValue = XF.Entry.CursorPositionProperty.DefaultValue is int value ? value : default;
         private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.Entry.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
@@ -22,8 +20,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly XF.ReturnType ReturnTypeDefaultValue = XF.Entry.ReturnTypeProperty.DefaultValue is XF.ReturnType value ? value : default;
         private static readonly int SelectionLengthDefaultValue = XF.Entry.SelectionLengthProperty.DefaultValue is int value ? value : default;
         private static readonly XF.TextAlignment VerticalTextAlignmentDefaultValue = XF.Entry.VerticalTextAlignmentProperty.DefaultValue is XF.TextAlignment value ? value : default;
-
-        #endregion Default values
 
         public EntryHandler(NativeComponentRenderer renderer, XF.Entry entryControl) : base(renderer, entryControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/EntryHandler.generated.cs
@@ -9,6 +9,22 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class EntryHandler : InputViewHandler
     {
+        #region Default values
+
+        private static readonly XF.ClearButtonVisibility ClearButtonVisibilityDefaultValue = XF.Entry.ClearButtonVisibilityProperty.DefaultValue is XF.ClearButtonVisibility value ? value : default;
+        private static readonly int CursorPositionDefaultValue = XF.Entry.CursorPositionProperty.DefaultValue is int value ? value : default;
+        private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.Entry.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
+        private static readonly string FontFamilyDefaultValue = XF.Entry.FontFamilyProperty.DefaultValue is string value ? value : default;
+        private static readonly double FontSizeDefaultValue = XF.Entry.FontSizeProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.TextAlignment HorizontalTextAlignmentDefaultValue = XF.Entry.HorizontalTextAlignmentProperty.DefaultValue is XF.TextAlignment value ? value : default;
+        private static readonly bool IsPasswordDefaultValue = XF.Entry.IsPasswordProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsTextPredictionEnabledDefaultValue = XF.Entry.IsTextPredictionEnabledProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.ReturnType ReturnTypeDefaultValue = XF.Entry.ReturnTypeProperty.DefaultValue is XF.ReturnType value ? value : default;
+        private static readonly int SelectionLengthDefaultValue = XF.Entry.SelectionLengthProperty.DefaultValue is int value ? value : default;
+        private static readonly XF.TextAlignment VerticalTextAlignmentDefaultValue = XF.Entry.VerticalTextAlignmentProperty.DefaultValue is XF.TextAlignment value ? value : default;
+
+        #endregion Default values
+
         public EntryHandler(NativeComponentRenderer renderer, XF.Entry entryControl) : base(renderer, entryControl)
         {
             EntryControl = entryControl ?? throw new ArgumentNullException(nameof(entryControl));
@@ -25,37 +41,37 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Entry.ClearButtonVisibility):
-                    EntryControl.ClearButtonVisibility = (XF.ClearButtonVisibility)AttributeHelper.GetInt(attributeValue);
+                    EntryControl.ClearButtonVisibility = (XF.ClearButtonVisibility)AttributeHelper.GetInt(attributeValue, (int)ClearButtonVisibilityDefaultValue);
                     break;
                 case nameof(XF.Entry.CursorPosition):
-                    EntryControl.CursorPosition = AttributeHelper.GetInt(attributeValue);
+                    EntryControl.CursorPosition = AttributeHelper.GetInt(attributeValue, CursorPositionDefaultValue);
                     break;
                 case nameof(XF.Entry.FontAttributes):
-                    EntryControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue);
+                    EntryControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue, (int)FontAttributesDefaultValue);
                     break;
                 case nameof(XF.Entry.FontFamily):
-                    EntryControl.FontFamily = (string)attributeValue;
+                    EntryControl.FontFamily = (string)attributeValue ?? FontFamilyDefaultValue;
                     break;
                 case nameof(XF.Entry.FontSize):
-                    EntryControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    EntryControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, FontSizeDefaultValue);
                     break;
                 case nameof(XF.Entry.HorizontalTextAlignment):
-                    EntryControl.HorizontalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue);
+                    EntryControl.HorizontalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue, (int)HorizontalTextAlignmentDefaultValue);
                     break;
                 case nameof(XF.Entry.IsPassword):
-                    EntryControl.IsPassword = AttributeHelper.GetBool(attributeValue);
+                    EntryControl.IsPassword = AttributeHelper.GetBool(attributeValue, IsPasswordDefaultValue);
                     break;
                 case nameof(XF.Entry.IsTextPredictionEnabled):
-                    EntryControl.IsTextPredictionEnabled = AttributeHelper.GetBool(attributeValue, true);
+                    EntryControl.IsTextPredictionEnabled = AttributeHelper.GetBool(attributeValue, IsTextPredictionEnabledDefaultValue);
                     break;
                 case nameof(XF.Entry.ReturnType):
-                    EntryControl.ReturnType = (XF.ReturnType)AttributeHelper.GetInt(attributeValue);
+                    EntryControl.ReturnType = (XF.ReturnType)AttributeHelper.GetInt(attributeValue, (int)ReturnTypeDefaultValue);
                     break;
                 case nameof(XF.Entry.SelectionLength):
-                    EntryControl.SelectionLength = AttributeHelper.GetInt(attributeValue);
+                    EntryControl.SelectionLength = AttributeHelper.GetInt(attributeValue, SelectionLengthDefaultValue);
                     break;
                 case nameof(XF.Entry.VerticalTextAlignment):
-                    EntryControl.VerticalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue, (int)XF.TextAlignment.Center);
+                    EntryControl.VerticalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue, (int)VerticalTextAlignmentDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FlyoutItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FlyoutItemHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class FlyoutItemHandler : ShellItemHandler
     {
+
         public FlyoutItemHandler(NativeComponentRenderer renderer, XF.FlyoutItem flyoutItemControl) : base(renderer, flyoutItemControl)
         {
             FlyoutItemControl = flyoutItemControl ?? throw new ArgumentNullException(nameof(flyoutItemControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FlyoutPageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FlyoutPageHandler.generated.cs
@@ -9,13 +9,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class FlyoutPageHandler : PageHandler
     {
-        #region Default values
-
         private static readonly XF.FlyoutLayoutBehavior FlyoutLayoutBehaviorDefaultValue = XF.FlyoutPage.FlyoutLayoutBehaviorProperty.DefaultValue is XF.FlyoutLayoutBehavior value ? value : default;
         private static readonly bool IsGestureEnabledDefaultValue = XF.FlyoutPage.IsGestureEnabledProperty.DefaultValue is bool value ? value : default;
         private static readonly bool IsPresentedDefaultValue = XF.FlyoutPage.IsPresentedProperty.DefaultValue is bool value ? value : default;
-
-        #endregion Default values
 
         public FlyoutPageHandler(NativeComponentRenderer renderer, XF.FlyoutPage flyoutPageControl) : base(renderer, flyoutPageControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FlyoutPageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FlyoutPageHandler.generated.cs
@@ -9,6 +9,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class FlyoutPageHandler : PageHandler
     {
+        #region Default values
+
+        private static readonly XF.FlyoutLayoutBehavior FlyoutLayoutBehaviorDefaultValue = XF.FlyoutPage.FlyoutLayoutBehaviorProperty.DefaultValue is XF.FlyoutLayoutBehavior value ? value : default;
+        private static readonly bool IsGestureEnabledDefaultValue = XF.FlyoutPage.IsGestureEnabledProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsPresentedDefaultValue = XF.FlyoutPage.IsPresentedProperty.DefaultValue is bool value ? value : default;
+
+        #endregion Default values
+
         public FlyoutPageHandler(NativeComponentRenderer renderer, XF.FlyoutPage flyoutPageControl) : base(renderer, flyoutPageControl)
         {
             FlyoutPageControl = flyoutPageControl ?? throw new ArgumentNullException(nameof(flyoutPageControl));
@@ -25,13 +33,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.FlyoutPage.FlyoutLayoutBehavior):
-                    FlyoutPageControl.FlyoutLayoutBehavior = (XF.FlyoutLayoutBehavior)AttributeHelper.GetInt(attributeValue);
+                    FlyoutPageControl.FlyoutLayoutBehavior = (XF.FlyoutLayoutBehavior)AttributeHelper.GetInt(attributeValue, (int)FlyoutLayoutBehaviorDefaultValue);
                     break;
                 case nameof(XF.FlyoutPage.IsGestureEnabled):
-                    FlyoutPageControl.IsGestureEnabled = AttributeHelper.GetBool(attributeValue, true);
+                    FlyoutPageControl.IsGestureEnabled = AttributeHelper.GetBool(attributeValue, IsGestureEnabledDefaultValue);
                     break;
                 case nameof(XF.FlyoutPage.IsPresented):
-                    FlyoutPageControl.IsPresented = AttributeHelper.GetBool(attributeValue);
+                    FlyoutPageControl.IsPresented = AttributeHelper.GetBool(attributeValue, IsPresentedDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FrameHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FrameHandler.generated.cs
@@ -9,13 +9,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class FrameHandler : ContentViewHandler
     {
-        #region Default values
-
         private static readonly XF.Color BorderColorDefaultValue = XF.Frame.BorderColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly float CornerRadiusDefaultValue = XF.Frame.CornerRadiusProperty.DefaultValue is float value ? value : default;
         private static readonly bool HasShadowDefaultValue = XF.Frame.HasShadowProperty.DefaultValue is bool value ? value : default;
-
-        #endregion Default values
 
         public FrameHandler(NativeComponentRenderer renderer, XF.Frame frameControl) : base(renderer, frameControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FrameHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/FrameHandler.generated.cs
@@ -9,6 +9,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class FrameHandler : ContentViewHandler
     {
+        #region Default values
+
+        private static readonly XF.Color BorderColorDefaultValue = XF.Frame.BorderColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly float CornerRadiusDefaultValue = XF.Frame.CornerRadiusProperty.DefaultValue is float value ? value : default;
+        private static readonly bool HasShadowDefaultValue = XF.Frame.HasShadowProperty.DefaultValue is bool value ? value : default;
+
+        #endregion Default values
+
         public FrameHandler(NativeComponentRenderer renderer, XF.Frame frameControl) : base(renderer, frameControl)
         {
             FrameControl = frameControl ?? throw new ArgumentNullException(nameof(frameControl));
@@ -25,13 +33,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Frame.BorderColor):
-                    FrameControl.BorderColor = AttributeHelper.StringToColor((string)attributeValue);
+                    FrameControl.BorderColor = AttributeHelper.StringToColor((string)attributeValue, BorderColorDefaultValue);
                     break;
                 case nameof(XF.Frame.CornerRadius):
-                    FrameControl.CornerRadius = AttributeHelper.StringToSingle((string)attributeValue, -1.00f);
+                    FrameControl.CornerRadius = AttributeHelper.StringToSingle((string)attributeValue, CornerRadiusDefaultValue);
                     break;
                 case nameof(XF.Frame.HasShadow):
-                    FrameControl.HasShadow = AttributeHelper.GetBool(attributeValue, true);
+                    FrameControl.HasShadow = AttributeHelper.GetBool(attributeValue, HasShadowDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GestureElementHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GestureElementHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class GestureElementHandler : ElementHandler
     {
+
         public GestureElementHandler(NativeComponentRenderer renderer, XF.GestureElement gestureElementControl) : base(renderer, gestureElementControl)
         {
             GestureElementControl = gestureElementControl ?? throw new ArgumentNullException(nameof(gestureElementControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.generated.cs
@@ -9,12 +9,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class GridHandler : LayoutHandler
     {
-        #region Default values
-
         private static readonly double ColumnSpacingDefaultValue = XF.Grid.ColumnSpacingProperty.DefaultValue is double value ? value : default;
         private static readonly double RowSpacingDefaultValue = XF.Grid.RowSpacingProperty.DefaultValue is double value ? value : default;
-
-        #endregion Default values
 
         public GridHandler(NativeComponentRenderer renderer, XF.Grid gridControl) : base(renderer, gridControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/GridHandler.generated.cs
@@ -9,6 +9,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class GridHandler : LayoutHandler
     {
+        #region Default values
+
+        private static readonly double ColumnSpacingDefaultValue = XF.Grid.ColumnSpacingProperty.DefaultValue is double value ? value : default;
+        private static readonly double RowSpacingDefaultValue = XF.Grid.RowSpacingProperty.DefaultValue is double value ? value : default;
+
+        #endregion Default values
+
         public GridHandler(NativeComponentRenderer renderer, XF.Grid gridControl) : base(renderer, gridControl)
         {
             GridControl = gridControl ?? throw new ArgumentNullException(nameof(gridControl));
@@ -25,10 +32,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Grid.ColumnSpacing):
-                    GridControl.ColumnSpacing = AttributeHelper.StringToDouble((string)attributeValue, 6.00);
+                    GridControl.ColumnSpacing = AttributeHelper.StringToDouble((string)attributeValue, ColumnSpacingDefaultValue);
                     break;
                 case nameof(XF.Grid.RowSpacing):
-                    GridControl.RowSpacing = AttributeHelper.StringToDouble((string)attributeValue, 6.00);
+                    GridControl.RowSpacing = AttributeHelper.StringToDouble((string)attributeValue, RowSpacingDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.generated.cs
@@ -9,6 +9,18 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ImageButtonHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly XF.Aspect AspectDefaultValue = XF.ImageButton.AspectProperty.DefaultValue is XF.Aspect value ? value : default;
+        private static readonly XF.Color BorderColorDefaultValue = XF.ImageButton.BorderColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly double BorderWidthDefaultValue = XF.ImageButton.BorderWidthProperty.DefaultValue is double value ? value : default;
+        private static readonly int CornerRadiusDefaultValue = XF.ImageButton.CornerRadiusProperty.DefaultValue is int value ? value : default;
+        private static readonly bool IsOpaqueDefaultValue = XF.ImageButton.IsOpaqueProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.Thickness PaddingDefaultValue = XF.ImageButton.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
+        private static readonly XF.ImageSource SourceDefaultValue = XF.ImageButton.SourceProperty.DefaultValue is XF.ImageSource value ? value : default;
+
+        #endregion Default values
+
         public ImageButtonHandler(NativeComponentRenderer renderer, XF.ImageButton imageButtonControl) : base(renderer, imageButtonControl)
         {
             ImageButtonControl = imageButtonControl ?? throw new ArgumentNullException(nameof(imageButtonControl));
@@ -25,25 +37,25 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.ImageButton.Aspect):
-                    ImageButtonControl.Aspect = (XF.Aspect)AttributeHelper.GetInt(attributeValue);
+                    ImageButtonControl.Aspect = (XF.Aspect)AttributeHelper.GetInt(attributeValue, (int)AspectDefaultValue);
                     break;
                 case nameof(XF.ImageButton.BorderColor):
-                    ImageButtonControl.BorderColor = AttributeHelper.StringToColor((string)attributeValue);
+                    ImageButtonControl.BorderColor = AttributeHelper.StringToColor((string)attributeValue, BorderColorDefaultValue);
                     break;
                 case nameof(XF.ImageButton.BorderWidth):
-                    ImageButtonControl.BorderWidth = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    ImageButtonControl.BorderWidth = AttributeHelper.StringToDouble((string)attributeValue, BorderWidthDefaultValue);
                     break;
                 case nameof(XF.ImageButton.CornerRadius):
-                    ImageButtonControl.CornerRadius = AttributeHelper.GetInt(attributeValue, -1);
+                    ImageButtonControl.CornerRadius = AttributeHelper.GetInt(attributeValue, CornerRadiusDefaultValue);
                     break;
                 case nameof(XF.ImageButton.IsOpaque):
-                    ImageButtonControl.IsOpaque = AttributeHelper.GetBool(attributeValue);
+                    ImageButtonControl.IsOpaque = AttributeHelper.GetBool(attributeValue, IsOpaqueDefaultValue);
                     break;
                 case nameof(XF.ImageButton.Padding):
-                    ImageButtonControl.Padding = AttributeHelper.StringToThickness(attributeValue);
+                    ImageButtonControl.Padding = AttributeHelper.StringToThickness(attributeValue, PaddingDefaultValue);
                     break;
                 case nameof(XF.ImageButton.Source):
-                    ImageButtonControl.Source = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    ImageButtonControl.Source = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, SourceDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageButtonHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ImageButtonHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly XF.Aspect AspectDefaultValue = XF.ImageButton.AspectProperty.DefaultValue is XF.Aspect value ? value : default;
         private static readonly XF.Color BorderColorDefaultValue = XF.ImageButton.BorderColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly double BorderWidthDefaultValue = XF.ImageButton.BorderWidthProperty.DefaultValue is double value ? value : default;
@@ -18,8 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly bool IsOpaqueDefaultValue = XF.ImageButton.IsOpaqueProperty.DefaultValue is bool value ? value : default;
         private static readonly XF.Thickness PaddingDefaultValue = XF.ImageButton.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
         private static readonly XF.ImageSource SourceDefaultValue = XF.ImageButton.SourceProperty.DefaultValue is XF.ImageSource value ? value : default;
-
-        #endregion Default values
 
         public ImageButtonHandler(NativeComponentRenderer renderer, XF.ImageButton imageButtonControl) : base(renderer, imageButtonControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageHandler.generated.cs
@@ -9,6 +9,15 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ImageHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly XF.Aspect AspectDefaultValue = XF.Image.AspectProperty.DefaultValue is XF.Aspect value ? value : default;
+        private static readonly bool IsAnimationPlayingDefaultValue = XF.Image.IsAnimationPlayingProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsOpaqueDefaultValue = XF.Image.IsOpaqueProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.ImageSource SourceDefaultValue = XF.Image.SourceProperty.DefaultValue is XF.ImageSource value ? value : default;
+
+        #endregion Default values
+
         public ImageHandler(NativeComponentRenderer renderer, XF.Image imageControl) : base(renderer, imageControl)
         {
             ImageControl = imageControl ?? throw new ArgumentNullException(nameof(imageControl));
@@ -25,16 +34,16 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Image.Aspect):
-                    ImageControl.Aspect = (XF.Aspect)AttributeHelper.GetInt(attributeValue);
+                    ImageControl.Aspect = (XF.Aspect)AttributeHelper.GetInt(attributeValue, (int)AspectDefaultValue);
                     break;
                 case nameof(XF.Image.IsAnimationPlaying):
-                    ImageControl.IsAnimationPlaying = AttributeHelper.GetBool(attributeValue);
+                    ImageControl.IsAnimationPlaying = AttributeHelper.GetBool(attributeValue, IsAnimationPlayingDefaultValue);
                     break;
                 case nameof(XF.Image.IsOpaque):
-                    ImageControl.IsOpaque = AttributeHelper.GetBool(attributeValue);
+                    ImageControl.IsOpaque = AttributeHelper.GetBool(attributeValue, IsOpaqueDefaultValue);
                     break;
                 case nameof(XF.Image.Source):
-                    ImageControl.Source = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    ImageControl.Source = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, SourceDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ImageHandler.generated.cs
@@ -9,14 +9,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ImageHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly XF.Aspect AspectDefaultValue = XF.Image.AspectProperty.DefaultValue is XF.Aspect value ? value : default;
         private static readonly bool IsAnimationPlayingDefaultValue = XF.Image.IsAnimationPlayingProperty.DefaultValue is bool value ? value : default;
         private static readonly bool IsOpaqueDefaultValue = XF.Image.IsOpaqueProperty.DefaultValue is bool value ? value : default;
         private static readonly XF.ImageSource SourceDefaultValue = XF.Image.SourceProperty.DefaultValue is XF.ImageSource value ? value : default;
-
-        #endregion Default values
 
         public ImageHandler(NativeComponentRenderer renderer, XF.Image imageControl) : base(renderer, imageControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/InputViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/InputViewHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class InputViewHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly double CharacterSpacingDefaultValue = XF.InputView.CharacterSpacingProperty.DefaultValue is double value ? value : default;
         private static readonly bool IsReadOnlyDefaultValue = XF.InputView.IsReadOnlyProperty.DefaultValue is bool value ? value : default;
         private static readonly bool IsSpellCheckEnabledDefaultValue = XF.InputView.IsSpellCheckEnabledProperty.DefaultValue is bool value ? value : default;
@@ -21,8 +19,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly string TextDefaultValue = XF.InputView.TextProperty.DefaultValue is string value ? value : default;
         private static readonly XF.Color TextColorDefaultValue = XF.InputView.TextColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.TextTransform TextTransformDefaultValue = XF.InputView.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
-
-        #endregion Default values
 
         public InputViewHandler(NativeComponentRenderer renderer, XF.InputView inputViewControl) : base(renderer, inputViewControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/InputViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/InputViewHandler.generated.cs
@@ -9,6 +9,21 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class InputViewHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly double CharacterSpacingDefaultValue = XF.InputView.CharacterSpacingProperty.DefaultValue is double value ? value : default;
+        private static readonly bool IsReadOnlyDefaultValue = XF.InputView.IsReadOnlyProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsSpellCheckEnabledDefaultValue = XF.InputView.IsSpellCheckEnabledProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.Keyboard KeyboardDefaultValue = XF.InputView.KeyboardProperty.DefaultValue is XF.Keyboard value ? value : default;
+        private static readonly int MaxLengthDefaultValue = XF.InputView.MaxLengthProperty.DefaultValue is int value ? value : default;
+        private static readonly string PlaceholderDefaultValue = XF.InputView.PlaceholderProperty.DefaultValue is string value ? value : default;
+        private static readonly XF.Color PlaceholderColorDefaultValue = XF.InputView.PlaceholderColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly string TextDefaultValue = XF.InputView.TextProperty.DefaultValue is string value ? value : default;
+        private static readonly XF.Color TextColorDefaultValue = XF.InputView.TextColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.TextTransform TextTransformDefaultValue = XF.InputView.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
+
+        #endregion Default values
+
         public InputViewHandler(NativeComponentRenderer renderer, XF.InputView inputViewControl) : base(renderer, inputViewControl)
         {
             InputViewControl = inputViewControl ?? throw new ArgumentNullException(nameof(inputViewControl));
@@ -25,34 +40,34 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.InputView.CharacterSpacing):
-                    InputViewControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue);
+                    InputViewControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue, CharacterSpacingDefaultValue);
                     break;
                 case nameof(XF.InputView.IsReadOnly):
-                    InputViewControl.IsReadOnly = AttributeHelper.GetBool(attributeValue);
+                    InputViewControl.IsReadOnly = AttributeHelper.GetBool(attributeValue, IsReadOnlyDefaultValue);
                     break;
                 case nameof(XF.InputView.IsSpellCheckEnabled):
-                    InputViewControl.IsSpellCheckEnabled = AttributeHelper.GetBool(attributeValue, true);
+                    InputViewControl.IsSpellCheckEnabled = AttributeHelper.GetBool(attributeValue, IsSpellCheckEnabledDefaultValue);
                     break;
                 case nameof(XF.InputView.Keyboard):
-                    InputViewControl.Keyboard = AttributeHelper.DelegateToObject<XF.Keyboard>(attributeValue);
+                    InputViewControl.Keyboard = AttributeHelper.DelegateToObject<XF.Keyboard>(attributeValue, KeyboardDefaultValue);
                     break;
                 case nameof(XF.InputView.MaxLength):
-                    InputViewControl.MaxLength = AttributeHelper.GetInt(attributeValue, int.MaxValue);
+                    InputViewControl.MaxLength = AttributeHelper.GetInt(attributeValue, MaxLengthDefaultValue);
                     break;
                 case nameof(XF.InputView.Placeholder):
-                    InputViewControl.Placeholder = (string)attributeValue;
+                    InputViewControl.Placeholder = (string)attributeValue ?? PlaceholderDefaultValue;
                     break;
                 case nameof(XF.InputView.PlaceholderColor):
-                    InputViewControl.PlaceholderColor = AttributeHelper.StringToColor((string)attributeValue);
+                    InputViewControl.PlaceholderColor = AttributeHelper.StringToColor((string)attributeValue, PlaceholderColorDefaultValue);
                     break;
                 case nameof(XF.InputView.Text):
-                    InputViewControl.Text = (string)attributeValue;
+                    InputViewControl.Text = (string)attributeValue ?? TextDefaultValue;
                     break;
                 case nameof(XF.InputView.TextColor):
-                    InputViewControl.TextColor = AttributeHelper.StringToColor((string)attributeValue);
+                    InputViewControl.TextColor = AttributeHelper.StringToColor((string)attributeValue, TextColorDefaultValue);
                     break;
                 case nameof(XF.InputView.TextTransform):
-                    InputViewControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)XF.TextTransform.Default);
+                    InputViewControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)TextTransformDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.generated.cs
@@ -9,6 +9,26 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class LabelHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly double CharacterSpacingDefaultValue = XF.Label.CharacterSpacingProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.Label.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
+        private static readonly string FontFamilyDefaultValue = XF.Label.FontFamilyProperty.DefaultValue is string value ? value : default;
+        private static readonly double FontSizeDefaultValue = XF.Label.FontSizeProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.TextAlignment HorizontalTextAlignmentDefaultValue = XF.Label.HorizontalTextAlignmentProperty.DefaultValue is XF.TextAlignment value ? value : default;
+        private static readonly XF.LineBreakMode LineBreakModeDefaultValue = XF.Label.LineBreakModeProperty.DefaultValue is XF.LineBreakMode value ? value : default;
+        private static readonly double LineHeightDefaultValue = XF.Label.LineHeightProperty.DefaultValue is double value ? value : default;
+        private static readonly int MaxLinesDefaultValue = XF.Label.MaxLinesProperty.DefaultValue is int value ? value : default;
+        private static readonly XF.Thickness PaddingDefaultValue = XF.Label.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
+        private static readonly string TextDefaultValue = XF.Label.TextProperty.DefaultValue is string value ? value : default;
+        private static readonly XF.Color TextColorDefaultValue = XF.Label.TextColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.TextDecorations TextDecorationsDefaultValue = XF.Label.TextDecorationsProperty.DefaultValue is XF.TextDecorations value ? value : default;
+        private static readonly XF.TextTransform TextTransformDefaultValue = XF.Label.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
+        private static readonly XF.TextType TextTypeDefaultValue = XF.Label.TextTypeProperty.DefaultValue is XF.TextType value ? value : default;
+        private static readonly XF.TextAlignment VerticalTextAlignmentDefaultValue = XF.Label.VerticalTextAlignmentProperty.DefaultValue is XF.TextAlignment value ? value : default;
+
+        #endregion Default values
+
         public LabelHandler(NativeComponentRenderer renderer, XF.Label labelControl) : base(renderer, labelControl)
         {
             LabelControl = labelControl ?? throw new ArgumentNullException(nameof(labelControl));
@@ -25,49 +45,49 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Label.CharacterSpacing):
-                    LabelControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue);
+                    LabelControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue, CharacterSpacingDefaultValue);
                     break;
                 case nameof(XF.Label.FontAttributes):
-                    LabelControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue);
+                    LabelControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue, (int)FontAttributesDefaultValue);
                     break;
                 case nameof(XF.Label.FontFamily):
-                    LabelControl.FontFamily = (string)attributeValue;
+                    LabelControl.FontFamily = (string)attributeValue ?? FontFamilyDefaultValue;
                     break;
                 case nameof(XF.Label.FontSize):
-                    LabelControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    LabelControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, FontSizeDefaultValue);
                     break;
                 case nameof(XF.Label.HorizontalTextAlignment):
-                    LabelControl.HorizontalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue);
+                    LabelControl.HorizontalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue, (int)HorizontalTextAlignmentDefaultValue);
                     break;
                 case nameof(XF.Label.LineBreakMode):
-                    LabelControl.LineBreakMode = (XF.LineBreakMode)AttributeHelper.GetInt(attributeValue, (int)XF.LineBreakMode.WordWrap);
+                    LabelControl.LineBreakMode = (XF.LineBreakMode)AttributeHelper.GetInt(attributeValue, (int)LineBreakModeDefaultValue);
                     break;
                 case nameof(XF.Label.LineHeight):
-                    LabelControl.LineHeight = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    LabelControl.LineHeight = AttributeHelper.StringToDouble((string)attributeValue, LineHeightDefaultValue);
                     break;
                 case nameof(XF.Label.MaxLines):
-                    LabelControl.MaxLines = AttributeHelper.GetInt(attributeValue, -1);
+                    LabelControl.MaxLines = AttributeHelper.GetInt(attributeValue, MaxLinesDefaultValue);
                     break;
                 case nameof(XF.Label.Padding):
-                    LabelControl.Padding = AttributeHelper.StringToThickness(attributeValue);
+                    LabelControl.Padding = AttributeHelper.StringToThickness(attributeValue, PaddingDefaultValue);
                     break;
                 case nameof(XF.Label.Text):
-                    LabelControl.Text = (string)attributeValue;
+                    LabelControl.Text = (string)attributeValue ?? TextDefaultValue;
                     break;
                 case nameof(XF.Label.TextColor):
-                    LabelControl.TextColor = AttributeHelper.StringToColor((string)attributeValue);
+                    LabelControl.TextColor = AttributeHelper.StringToColor((string)attributeValue, TextColorDefaultValue);
                     break;
                 case nameof(XF.Label.TextDecorations):
-                    LabelControl.TextDecorations = (XF.TextDecorations)AttributeHelper.GetInt(attributeValue);
+                    LabelControl.TextDecorations = (XF.TextDecorations)AttributeHelper.GetInt(attributeValue, (int)TextDecorationsDefaultValue);
                     break;
                 case nameof(XF.Label.TextTransform):
-                    LabelControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)XF.TextTransform.Default);
+                    LabelControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)TextTransformDefaultValue);
                     break;
                 case nameof(XF.Label.TextType):
-                    LabelControl.TextType = (XF.TextType)AttributeHelper.GetInt(attributeValue);
+                    LabelControl.TextType = (XF.TextType)AttributeHelper.GetInt(attributeValue, (int)TextTypeDefaultValue);
                     break;
                 case nameof(XF.Label.VerticalTextAlignment):
-                    LabelControl.VerticalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue);
+                    LabelControl.VerticalTextAlignment = (XF.TextAlignment)AttributeHelper.GetInt(attributeValue, (int)VerticalTextAlignmentDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LabelHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class LabelHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly double CharacterSpacingDefaultValue = XF.Label.CharacterSpacingProperty.DefaultValue is double value ? value : default;
         private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.Label.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
         private static readonly string FontFamilyDefaultValue = XF.Label.FontFamilyProperty.DefaultValue is string value ? value : default;
@@ -26,8 +24,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly XF.TextTransform TextTransformDefaultValue = XF.Label.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
         private static readonly XF.TextType TextTypeDefaultValue = XF.Label.TextTypeProperty.DefaultValue is XF.TextType value ? value : default;
         private static readonly XF.TextAlignment VerticalTextAlignmentDefaultValue = XF.Label.VerticalTextAlignmentProperty.DefaultValue is XF.TextAlignment value ? value : default;
-
-        #endregion Default values
 
         public LabelHandler(NativeComponentRenderer renderer, XF.Label labelControl) : base(renderer, labelControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.generated.cs
@@ -9,13 +9,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public abstract partial class LayoutHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly bool CascadeInputTransparentDefaultValue = XF.Layout.CascadeInputTransparentProperty.DefaultValue is bool value ? value : default;
         private static readonly bool IsClippedToBoundsDefaultValue = XF.Layout.IsClippedToBoundsProperty.DefaultValue is bool value ? value : default;
         private static readonly XF.Thickness PaddingDefaultValue = XF.Layout.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
-
-        #endregion Default values
 
         public LayoutHandler(NativeComponentRenderer renderer, XF.Layout layoutControl) : base(renderer, layoutControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/LayoutHandler.generated.cs
@@ -9,6 +9,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public abstract partial class LayoutHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly bool CascadeInputTransparentDefaultValue = XF.Layout.CascadeInputTransparentProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsClippedToBoundsDefaultValue = XF.Layout.IsClippedToBoundsProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.Thickness PaddingDefaultValue = XF.Layout.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
+
+        #endregion Default values
+
         public LayoutHandler(NativeComponentRenderer renderer, XF.Layout layoutControl) : base(renderer, layoutControl)
         {
             LayoutControl = layoutControl ?? throw new ArgumentNullException(nameof(layoutControl));
@@ -25,13 +33,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Layout.CascadeInputTransparent):
-                    LayoutControl.CascadeInputTransparent = AttributeHelper.GetBool(attributeValue, true);
+                    LayoutControl.CascadeInputTransparent = AttributeHelper.GetBool(attributeValue, CascadeInputTransparentDefaultValue);
                     break;
                 case nameof(XF.Layout.IsClippedToBounds):
-                    LayoutControl.IsClippedToBounds = AttributeHelper.GetBool(attributeValue);
+                    LayoutControl.IsClippedToBounds = AttributeHelper.GetBool(attributeValue, IsClippedToBoundsDefaultValue);
                     break;
                 case nameof(XF.Layout.Padding):
-                    LayoutControl.Padding = AttributeHelper.StringToThickness(attributeValue);
+                    LayoutControl.Padding = AttributeHelper.StringToThickness(attributeValue, PaddingDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.generated.cs
@@ -9,6 +9,15 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class MenuItemHandler : BaseMenuItemHandler
     {
+        #region Default values
+
+        private static readonly XF.ImageSource IconImageSourceDefaultValue = XF.MenuItem.IconImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly bool IsDestructiveDefaultValue = XF.MenuItem.IsDestructiveProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsEnabledDefaultValue = XF.MenuItem.IsEnabledProperty.DefaultValue is bool value ? value : default;
+        private static readonly string TextDefaultValue = XF.MenuItem.TextProperty.DefaultValue is string value ? value : default;
+
+        #endregion Default values
+
         public MenuItemHandler(NativeComponentRenderer renderer, XF.MenuItem menuItemControl) : base(renderer, menuItemControl)
         {
             MenuItemControl = menuItemControl ?? throw new ArgumentNullException(nameof(menuItemControl));
@@ -28,19 +37,19 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
                     MenuItemControl.@class = AttributeHelper.GetStringList(attributeValue);
                     break;
                 case nameof(XF.MenuItem.IconImageSource):
-                    MenuItemControl.IconImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    MenuItemControl.IconImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, IconImageSourceDefaultValue);
                     break;
                 case nameof(XF.MenuItem.IsDestructive):
-                    MenuItemControl.IsDestructive = AttributeHelper.GetBool(attributeValue);
+                    MenuItemControl.IsDestructive = AttributeHelper.GetBool(attributeValue, IsDestructiveDefaultValue);
                     break;
                 case nameof(XF.MenuItem.IsEnabled):
-                    MenuItemControl.IsEnabled = AttributeHelper.GetBool(attributeValue, true);
+                    MenuItemControl.IsEnabled = AttributeHelper.GetBool(attributeValue, IsEnabledDefaultValue);
                     break;
                 case nameof(XF.MenuItem.StyleClass):
                     MenuItemControl.StyleClass = AttributeHelper.GetStringList(attributeValue);
                     break;
                 case nameof(XF.MenuItem.Text):
-                    MenuItemControl.Text = (string)attributeValue;
+                    MenuItemControl.Text = (string)attributeValue ?? TextDefaultValue;
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/MenuItemHandler.generated.cs
@@ -9,14 +9,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class MenuItemHandler : BaseMenuItemHandler
     {
-        #region Default values
-
         private static readonly XF.ImageSource IconImageSourceDefaultValue = XF.MenuItem.IconImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
         private static readonly bool IsDestructiveDefaultValue = XF.MenuItem.IsDestructiveProperty.DefaultValue is bool value ? value : default;
         private static readonly bool IsEnabledDefaultValue = XF.MenuItem.IsEnabledProperty.DefaultValue is bool value ? value : default;
         private static readonly string TextDefaultValue = XF.MenuItem.TextProperty.DefaultValue is string value ? value : default;
-
-        #endregion Default values
 
         public MenuItemHandler(NativeComponentRenderer renderer, XF.MenuItem menuItemControl) : base(renderer, menuItemControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/NavigableElementHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/NavigableElementHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class NavigableElementHandler : ElementHandler
     {
+
         public NavigableElementHandler(NativeComponentRenderer renderer, XF.NavigableElement navigableElementControl) : base(renderer, navigableElementControl)
         {
             NavigableElementControl = navigableElementControl ?? throw new ArgumentNullException(nameof(navigableElementControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/PageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/PageHandler.generated.cs
@@ -9,6 +9,16 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class PageHandler : VisualElementHandler
     {
+        #region Default values
+
+        private static readonly XF.ImageSource BackgroundImageSourceDefaultValue = XF.Page.BackgroundImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly XF.ImageSource IconImageSourceDefaultValue = XF.Page.IconImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly bool IsBusyDefaultValue = XF.Page.IsBusyProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.Thickness PaddingDefaultValue = XF.Page.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
+        private static readonly string TitleDefaultValue = XF.Page.TitleProperty.DefaultValue is string value ? value : default;
+
+        #endregion Default values
+
         public PageHandler(NativeComponentRenderer renderer, XF.Page pageControl) : base(renderer, pageControl)
         {
             PageControl = pageControl ?? throw new ArgumentNullException(nameof(pageControl));
@@ -25,19 +35,19 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Page.BackgroundImageSource):
-                    PageControl.BackgroundImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    PageControl.BackgroundImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, BackgroundImageSourceDefaultValue);
                     break;
                 case nameof(XF.Page.IconImageSource):
-                    PageControl.IconImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    PageControl.IconImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, IconImageSourceDefaultValue);
                     break;
                 case nameof(XF.Page.IsBusy):
-                    PageControl.IsBusy = AttributeHelper.GetBool(attributeValue);
+                    PageControl.IsBusy = AttributeHelper.GetBool(attributeValue, IsBusyDefaultValue);
                     break;
                 case nameof(XF.Page.Padding):
-                    PageControl.Padding = AttributeHelper.StringToThickness(attributeValue);
+                    PageControl.Padding = AttributeHelper.StringToThickness(attributeValue, PaddingDefaultValue);
                     break;
                 case nameof(XF.Page.Title):
-                    PageControl.Title = (string)attributeValue;
+                    PageControl.Title = (string)attributeValue ?? TitleDefaultValue;
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/PageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/PageHandler.generated.cs
@@ -9,15 +9,11 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class PageHandler : VisualElementHandler
     {
-        #region Default values
-
         private static readonly XF.ImageSource BackgroundImageSourceDefaultValue = XF.Page.BackgroundImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
         private static readonly XF.ImageSource IconImageSourceDefaultValue = XF.Page.IconImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
         private static readonly bool IsBusyDefaultValue = XF.Page.IsBusyProperty.DefaultValue is bool value ? value : default;
         private static readonly XF.Thickness PaddingDefaultValue = XF.Page.PaddingProperty.DefaultValue is XF.Thickness value ? value : default;
         private static readonly string TitleDefaultValue = XF.Page.TitleProperty.DefaultValue is string value ? value : default;
-
-        #endregion Default values
 
         public PageHandler(NativeComponentRenderer renderer, XF.Page pageControl) : base(renderer, pageControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ProgressBarHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ProgressBarHandler.generated.cs
@@ -9,6 +9,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ProgressBarHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly double ProgressDefaultValue = XF.ProgressBar.ProgressProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.Color ProgressColorDefaultValue = XF.ProgressBar.ProgressColorProperty.DefaultValue is XF.Color value ? value : default;
+
+        #endregion Default values
+
         public ProgressBarHandler(NativeComponentRenderer renderer, XF.ProgressBar progressBarControl) : base(renderer, progressBarControl)
         {
             ProgressBarControl = progressBarControl ?? throw new ArgumentNullException(nameof(progressBarControl));
@@ -25,10 +32,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.ProgressBar.Progress):
-                    ProgressBarControl.Progress = AttributeHelper.StringToDouble((string)attributeValue);
+                    ProgressBarControl.Progress = AttributeHelper.StringToDouble((string)attributeValue, ProgressDefaultValue);
                     break;
                 case nameof(XF.ProgressBar.ProgressColor):
-                    ProgressBarControl.ProgressColor = AttributeHelper.StringToColor((string)attributeValue);
+                    ProgressBarControl.ProgressColor = AttributeHelper.StringToColor((string)attributeValue, ProgressColorDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ProgressBarHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ProgressBarHandler.generated.cs
@@ -9,12 +9,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ProgressBarHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly double ProgressDefaultValue = XF.ProgressBar.ProgressProperty.DefaultValue is double value ? value : default;
         private static readonly XF.Color ProgressColorDefaultValue = XF.ProgressBar.ProgressColorProperty.DefaultValue is XF.Color value ? value : default;
-
-        #endregion Default values
 
         public ProgressBarHandler(NativeComponentRenderer renderer, XF.ProgressBar progressBarControl) : base(renderer, progressBarControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ScrollViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ScrollViewHandler.generated.cs
@@ -9,13 +9,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ScrollViewHandler : LayoutHandler
     {
-        #region Default values
-
         private static readonly XF.ScrollBarVisibility HorizontalScrollBarVisibilityDefaultValue = XF.ScrollView.HorizontalScrollBarVisibilityProperty.DefaultValue is XF.ScrollBarVisibility value ? value : default;
         private static readonly XF.ScrollOrientation OrientationDefaultValue = XF.ScrollView.OrientationProperty.DefaultValue is XF.ScrollOrientation value ? value : default;
         private static readonly XF.ScrollBarVisibility VerticalScrollBarVisibilityDefaultValue = XF.ScrollView.VerticalScrollBarVisibilityProperty.DefaultValue is XF.ScrollBarVisibility value ? value : default;
-
-        #endregion Default values
 
         public ScrollViewHandler(NativeComponentRenderer renderer, XF.ScrollView scrollViewControl) : base(renderer, scrollViewControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ScrollViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ScrollViewHandler.generated.cs
@@ -9,6 +9,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ScrollViewHandler : LayoutHandler
     {
+        #region Default values
+
+        private static readonly XF.ScrollBarVisibility HorizontalScrollBarVisibilityDefaultValue = XF.ScrollView.HorizontalScrollBarVisibilityProperty.DefaultValue is XF.ScrollBarVisibility value ? value : default;
+        private static readonly XF.ScrollOrientation OrientationDefaultValue = XF.ScrollView.OrientationProperty.DefaultValue is XF.ScrollOrientation value ? value : default;
+        private static readonly XF.ScrollBarVisibility VerticalScrollBarVisibilityDefaultValue = XF.ScrollView.VerticalScrollBarVisibilityProperty.DefaultValue is XF.ScrollBarVisibility value ? value : default;
+
+        #endregion Default values
+
         public ScrollViewHandler(NativeComponentRenderer renderer, XF.ScrollView scrollViewControl) : base(renderer, scrollViewControl)
         {
             ScrollViewControl = scrollViewControl ?? throw new ArgumentNullException(nameof(scrollViewControl));
@@ -25,13 +33,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.ScrollView.HorizontalScrollBarVisibility):
-                    ScrollViewControl.HorizontalScrollBarVisibility = (XF.ScrollBarVisibility)AttributeHelper.GetInt(attributeValue);
+                    ScrollViewControl.HorizontalScrollBarVisibility = (XF.ScrollBarVisibility)AttributeHelper.GetInt(attributeValue, (int)HorizontalScrollBarVisibilityDefaultValue);
                     break;
                 case nameof(XF.ScrollView.Orientation):
-                    ScrollViewControl.Orientation = (XF.ScrollOrientation)AttributeHelper.GetInt(attributeValue);
+                    ScrollViewControl.Orientation = (XF.ScrollOrientation)AttributeHelper.GetInt(attributeValue, (int)OrientationDefaultValue);
                     break;
                 case nameof(XF.ScrollView.VerticalScrollBarVisibility):
-                    ScrollViewControl.VerticalScrollBarVisibility = (XF.ScrollBarVisibility)AttributeHelper.GetInt(attributeValue);
+                    ScrollViewControl.VerticalScrollBarVisibility = (XF.ScrollBarVisibility)AttributeHelper.GetInt(attributeValue, (int)VerticalScrollBarVisibilityDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellContentHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellContentHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellContentHandler : BaseShellItemHandler
     {
+
         public ShellContentHandler(NativeComponentRenderer renderer, XF.ShellContent shellContentControl) : base(renderer, shellContentControl)
         {
             ShellContentControl = shellContentControl ?? throw new ArgumentNullException(nameof(shellContentControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellGroupItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellGroupItemHandler.generated.cs
@@ -9,11 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellGroupItemHandler : BaseShellItemHandler
     {
-        #region Default values
-
         private static readonly XF.FlyoutDisplayOptions FlyoutDisplayOptionsDefaultValue = XF.ShellGroupItem.FlyoutDisplayOptionsProperty.DefaultValue is XF.FlyoutDisplayOptions value ? value : default;
-
-        #endregion Default values
 
         public ShellGroupItemHandler(NativeComponentRenderer renderer, XF.ShellGroupItem shellGroupItemControl) : base(renderer, shellGroupItemControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellGroupItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellGroupItemHandler.generated.cs
@@ -9,6 +9,12 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellGroupItemHandler : BaseShellItemHandler
     {
+        #region Default values
+
+        private static readonly XF.FlyoutDisplayOptions FlyoutDisplayOptionsDefaultValue = XF.ShellGroupItem.FlyoutDisplayOptionsProperty.DefaultValue is XF.FlyoutDisplayOptions value ? value : default;
+
+        #endregion Default values
+
         public ShellGroupItemHandler(NativeComponentRenderer renderer, XF.ShellGroupItem shellGroupItemControl) : base(renderer, shellGroupItemControl)
         {
             ShellGroupItemControl = shellGroupItemControl ?? throw new ArgumentNullException(nameof(shellGroupItemControl));
@@ -25,7 +31,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.ShellGroupItem.FlyoutDisplayOptions):
-                    ShellGroupItemControl.FlyoutDisplayOptions = (XF.FlyoutDisplayOptions)AttributeHelper.GetInt(attributeValue);
+                    ShellGroupItemControl.FlyoutDisplayOptions = (XF.FlyoutDisplayOptions)AttributeHelper.GetInt(attributeValue, (int)FlyoutDisplayOptionsDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellHandler : PageHandler
     {
-        #region Default values
-
         private static readonly XF.Color FlyoutBackgroundColorDefaultValue = XF.Shell.FlyoutBackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.ImageSource FlyoutBackgroundImageDefaultValue = XF.Shell.FlyoutBackgroundImageProperty.DefaultValue is XF.ImageSource value ? value : default;
         private static readonly XF.Aspect FlyoutBackgroundImageAspectDefaultValue = XF.Shell.FlyoutBackgroundImageAspectProperty.DefaultValue is XF.Aspect value ? value : default;
@@ -21,8 +19,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly bool FlyoutIsPresentedDefaultValue = XF.Shell.FlyoutIsPresentedProperty.DefaultValue is bool value ? value : default;
         private static readonly XF.ScrollMode FlyoutVerticalScrollModeDefaultValue = XF.Shell.FlyoutVerticalScrollModeProperty.DefaultValue is XF.ScrollMode value ? value : default;
         private static readonly double FlyoutWidthDefaultValue = XF.Shell.FlyoutWidthProperty.DefaultValue is double value ? value : default;
-
-        #endregion Default values
 
         public ShellHandler(NativeComponentRenderer renderer, XF.Shell shellControl) : base(renderer, shellControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellHandler.generated.cs
@@ -9,6 +9,21 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellHandler : PageHandler
     {
+        #region Default values
+
+        private static readonly XF.Color FlyoutBackgroundColorDefaultValue = XF.Shell.FlyoutBackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.ImageSource FlyoutBackgroundImageDefaultValue = XF.Shell.FlyoutBackgroundImageProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly XF.Aspect FlyoutBackgroundImageAspectDefaultValue = XF.Shell.FlyoutBackgroundImageAspectProperty.DefaultValue is XF.Aspect value ? value : default;
+        private static readonly XF.FlyoutBehavior FlyoutBehaviorDefaultValue = XF.Shell.FlyoutBehaviorProperty.DefaultValue is XF.FlyoutBehavior value ? value : default;
+        private static readonly XF.FlyoutHeaderBehavior FlyoutHeaderBehaviorDefaultValue = XF.Shell.FlyoutHeaderBehaviorProperty.DefaultValue is XF.FlyoutHeaderBehavior value ? value : default;
+        private static readonly double FlyoutHeightDefaultValue = XF.Shell.FlyoutHeightProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.ImageSource FlyoutIconDefaultValue = XF.Shell.FlyoutIconProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly bool FlyoutIsPresentedDefaultValue = XF.Shell.FlyoutIsPresentedProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.ScrollMode FlyoutVerticalScrollModeDefaultValue = XF.Shell.FlyoutVerticalScrollModeProperty.DefaultValue is XF.ScrollMode value ? value : default;
+        private static readonly double FlyoutWidthDefaultValue = XF.Shell.FlyoutWidthProperty.DefaultValue is double value ? value : default;
+
+        #endregion Default values
+
         public ShellHandler(NativeComponentRenderer renderer, XF.Shell shellControl) : base(renderer, shellControl)
         {
             ShellControl = shellControl ?? throw new ArgumentNullException(nameof(shellControl));
@@ -25,34 +40,34 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Shell.FlyoutBackgroundColor):
-                    ShellControl.FlyoutBackgroundColor = AttributeHelper.StringToColor((string)attributeValue);
+                    ShellControl.FlyoutBackgroundColor = AttributeHelper.StringToColor((string)attributeValue, FlyoutBackgroundColorDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutBackgroundImage):
-                    ShellControl.FlyoutBackgroundImage = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    ShellControl.FlyoutBackgroundImage = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, FlyoutBackgroundImageDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutBackgroundImageAspect):
-                    ShellControl.FlyoutBackgroundImageAspect = (XF.Aspect)AttributeHelper.GetInt(attributeValue);
+                    ShellControl.FlyoutBackgroundImageAspect = (XF.Aspect)AttributeHelper.GetInt(attributeValue, (int)FlyoutBackgroundImageAspectDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutBehavior):
-                    ShellControl.FlyoutBehavior = (XF.FlyoutBehavior)AttributeHelper.GetInt(attributeValue, (int)XF.FlyoutBehavior.Flyout);
+                    ShellControl.FlyoutBehavior = (XF.FlyoutBehavior)AttributeHelper.GetInt(attributeValue, (int)FlyoutBehaviorDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutHeaderBehavior):
-                    ShellControl.FlyoutHeaderBehavior = (XF.FlyoutHeaderBehavior)AttributeHelper.GetInt(attributeValue);
+                    ShellControl.FlyoutHeaderBehavior = (XF.FlyoutHeaderBehavior)AttributeHelper.GetInt(attributeValue, (int)FlyoutHeaderBehaviorDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutHeight):
-                    ShellControl.FlyoutHeight = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    ShellControl.FlyoutHeight = AttributeHelper.StringToDouble((string)attributeValue, FlyoutHeightDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutIcon):
-                    ShellControl.FlyoutIcon = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    ShellControl.FlyoutIcon = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, FlyoutIconDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutIsPresented):
-                    ShellControl.FlyoutIsPresented = AttributeHelper.GetBool(attributeValue);
+                    ShellControl.FlyoutIsPresented = AttributeHelper.GetBool(attributeValue, FlyoutIsPresentedDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutVerticalScrollMode):
-                    ShellControl.FlyoutVerticalScrollMode = (XF.ScrollMode)AttributeHelper.GetInt(attributeValue, (int)XF.ScrollMode.Auto);
+                    ShellControl.FlyoutVerticalScrollMode = (XF.ScrollMode)AttributeHelper.GetInt(attributeValue, (int)FlyoutVerticalScrollModeDefaultValue);
                     break;
                 case nameof(XF.Shell.FlyoutWidth):
-                    ShellControl.FlyoutWidth = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    ShellControl.FlyoutWidth = AttributeHelper.StringToDouble((string)attributeValue, FlyoutWidthDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellItemHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellItemHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellItemHandler : ShellGroupItemHandler
     {
+
         public ShellItemHandler(NativeComponentRenderer renderer, XF.ShellItem shellItemControl) : base(renderer, shellItemControl)
         {
             ShellItemControl = shellItemControl ?? throw new ArgumentNullException(nameof(shellItemControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ShellSectionHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ShellSectionHandler : ShellGroupItemHandler
     {
+
         public ShellSectionHandler(NativeComponentRenderer renderer, XF.ShellSection shellSectionControl) : base(renderer, shellSectionControl)
         {
             ShellSectionControl = shellSectionControl ?? throw new ArgumentNullException(nameof(shellSectionControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.generated.cs
@@ -9,6 +9,18 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class SliderHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly double MaximumDefaultValue = XF.Slider.MaximumProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.Color MaximumTrackColorDefaultValue = XF.Slider.MaximumTrackColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly double MinimumDefaultValue = XF.Slider.MinimumProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.Color MinimumTrackColorDefaultValue = XF.Slider.MinimumTrackColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.Color ThumbColorDefaultValue = XF.Slider.ThumbColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.ImageSource ThumbImageSourceDefaultValue = XF.Slider.ThumbImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
+        private static readonly double ValueDefaultValue = XF.Slider.ValueProperty.DefaultValue is double value ? value : default;
+
+        #endregion Default values
+
         public SliderHandler(NativeComponentRenderer renderer, XF.Slider sliderControl) : base(renderer, sliderControl)
         {
             SliderControl = sliderControl ?? throw new ArgumentNullException(nameof(sliderControl));
@@ -25,25 +37,25 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Slider.Maximum):
-                    SliderControl.Maximum = AttributeHelper.StringToDouble((string)attributeValue, 1.00);
+                    SliderControl.Maximum = AttributeHelper.StringToDouble((string)attributeValue, MaximumDefaultValue);
                     break;
                 case nameof(XF.Slider.MaximumTrackColor):
-                    SliderControl.MaximumTrackColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SliderControl.MaximumTrackColor = AttributeHelper.StringToColor((string)attributeValue, MaximumTrackColorDefaultValue);
                     break;
                 case nameof(XF.Slider.Minimum):
-                    SliderControl.Minimum = AttributeHelper.StringToDouble((string)attributeValue);
+                    SliderControl.Minimum = AttributeHelper.StringToDouble((string)attributeValue, MinimumDefaultValue);
                     break;
                 case nameof(XF.Slider.MinimumTrackColor):
-                    SliderControl.MinimumTrackColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SliderControl.MinimumTrackColor = AttributeHelper.StringToColor((string)attributeValue, MinimumTrackColorDefaultValue);
                     break;
                 case nameof(XF.Slider.ThumbColor):
-                    SliderControl.ThumbColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SliderControl.ThumbColor = AttributeHelper.StringToColor((string)attributeValue, ThumbColorDefaultValue);
                     break;
                 case nameof(XF.Slider.ThumbImageSource):
-                    SliderControl.ThumbImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue);
+                    SliderControl.ThumbImageSource = AttributeHelper.DelegateToObject<XF.ImageSource>(attributeValue, ThumbImageSourceDefaultValue);
                     break;
                 case nameof(XF.Slider.Value):
-                    SliderControl.Value = AttributeHelper.StringToDouble((string)attributeValue);
+                    SliderControl.Value = AttributeHelper.StringToDouble((string)attributeValue, ValueDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SliderHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class SliderHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly double MaximumDefaultValue = XF.Slider.MaximumProperty.DefaultValue is double value ? value : default;
         private static readonly XF.Color MaximumTrackColorDefaultValue = XF.Slider.MaximumTrackColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly double MinimumDefaultValue = XF.Slider.MinimumProperty.DefaultValue is double value ? value : default;
@@ -18,8 +16,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly XF.Color ThumbColorDefaultValue = XF.Slider.ThumbColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.ImageSource ThumbImageSourceDefaultValue = XF.Slider.ThumbImageSourceProperty.DefaultValue is XF.ImageSource value ? value : default;
         private static readonly double ValueDefaultValue = XF.Slider.ValueProperty.DefaultValue is double value ? value : default;
-
-        #endregion Default values
 
         public SliderHandler(NativeComponentRenderer renderer, XF.Slider sliderControl) : base(renderer, sliderControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SpanHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SpanHandler.generated.cs
@@ -9,6 +9,22 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class SpanHandler : GestureElementHandler
     {
+        #region Default values
+
+        private static readonly XF.Color BackgroundColorDefaultValue = XF.Span.BackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly double CharacterSpacingDefaultValue = XF.Span.CharacterSpacingProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.Span.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
+        private static readonly string FontFamilyDefaultValue = XF.Span.FontFamilyProperty.DefaultValue is string value ? value : default;
+        private static readonly double FontSizeDefaultValue = XF.Span.FontSizeProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.Color ForegroundColorDefaultValue = XF.Span.ForegroundColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly double LineHeightDefaultValue = XF.Span.LineHeightProperty.DefaultValue is double value ? value : default;
+        private static readonly string TextDefaultValue = XF.Span.TextProperty.DefaultValue is string value ? value : default;
+        private static readonly XF.Color TextColorDefaultValue = XF.Span.TextColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.TextDecorations TextDecorationsDefaultValue = XF.Span.TextDecorationsProperty.DefaultValue is XF.TextDecorations value ? value : default;
+        private static readonly XF.TextTransform TextTransformDefaultValue = XF.Span.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
+
+        #endregion Default values
+
         public SpanHandler(NativeComponentRenderer renderer, XF.Span spanControl) : base(renderer, spanControl)
         {
             SpanControl = spanControl ?? throw new ArgumentNullException(nameof(spanControl));
@@ -25,37 +41,37 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Span.BackgroundColor):
-                    SpanControl.BackgroundColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SpanControl.BackgroundColor = AttributeHelper.StringToColor((string)attributeValue, BackgroundColorDefaultValue);
                     break;
                 case nameof(XF.Span.CharacterSpacing):
-                    SpanControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue);
+                    SpanControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue, CharacterSpacingDefaultValue);
                     break;
                 case nameof(XF.Span.FontAttributes):
-                    SpanControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue);
+                    SpanControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue, (int)FontAttributesDefaultValue);
                     break;
                 case nameof(XF.Span.FontFamily):
-                    SpanControl.FontFamily = (string)attributeValue;
+                    SpanControl.FontFamily = (string)attributeValue ?? FontFamilyDefaultValue;
                     break;
                 case nameof(XF.Span.FontSize):
-                    SpanControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    SpanControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, FontSizeDefaultValue);
                     break;
                 case nameof(XF.Span.ForegroundColor):
-                    SpanControl.ForegroundColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SpanControl.ForegroundColor = AttributeHelper.StringToColor((string)attributeValue, ForegroundColorDefaultValue);
                     break;
                 case nameof(XF.Span.LineHeight):
-                    SpanControl.LineHeight = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    SpanControl.LineHeight = AttributeHelper.StringToDouble((string)attributeValue, LineHeightDefaultValue);
                     break;
                 case nameof(XF.Span.Text):
-                    SpanControl.Text = (string)attributeValue ?? "";
+                    SpanControl.Text = (string)attributeValue ?? TextDefaultValue;
                     break;
                 case nameof(XF.Span.TextColor):
-                    SpanControl.TextColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SpanControl.TextColor = AttributeHelper.StringToColor((string)attributeValue, TextColorDefaultValue);
                     break;
                 case nameof(XF.Span.TextDecorations):
-                    SpanControl.TextDecorations = (XF.TextDecorations)AttributeHelper.GetInt(attributeValue);
+                    SpanControl.TextDecorations = (XF.TextDecorations)AttributeHelper.GetInt(attributeValue, (int)TextDecorationsDefaultValue);
                     break;
                 case nameof(XF.Span.TextTransform):
-                    SpanControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)XF.TextTransform.Default);
+                    SpanControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)TextTransformDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SpanHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SpanHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class SpanHandler : GestureElementHandler
     {
-        #region Default values
-
         private static readonly XF.Color BackgroundColorDefaultValue = XF.Span.BackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly double CharacterSpacingDefaultValue = XF.Span.CharacterSpacingProperty.DefaultValue is double value ? value : default;
         private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.Span.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
@@ -22,8 +20,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly XF.Color TextColorDefaultValue = XF.Span.TextColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.TextDecorations TextDecorationsDefaultValue = XF.Span.TextDecorationsProperty.DefaultValue is XF.TextDecorations value ? value : default;
         private static readonly XF.TextTransform TextTransformDefaultValue = XF.Span.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
-
-        #endregion Default values
 
         public SpanHandler(NativeComponentRenderer renderer, XF.Span spanControl) : base(renderer, spanControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StackLayoutHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StackLayoutHandler.generated.cs
@@ -9,6 +9,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class StackLayoutHandler : LayoutHandler
     {
+        #region Default values
+
+        private static readonly XF.StackOrientation OrientationDefaultValue = XF.StackLayout.OrientationProperty.DefaultValue is XF.StackOrientation value ? value : default;
+        private static readonly double SpacingDefaultValue = XF.StackLayout.SpacingProperty.DefaultValue is double value ? value : default;
+
+        #endregion Default values
+
         public StackLayoutHandler(NativeComponentRenderer renderer, XF.StackLayout stackLayoutControl) : base(renderer, stackLayoutControl)
         {
             StackLayoutControl = stackLayoutControl ?? throw new ArgumentNullException(nameof(stackLayoutControl));
@@ -25,10 +32,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.StackLayout.Orientation):
-                    StackLayoutControl.Orientation = (XF.StackOrientation)AttributeHelper.GetInt(attributeValue);
+                    StackLayoutControl.Orientation = (XF.StackOrientation)AttributeHelper.GetInt(attributeValue, (int)OrientationDefaultValue);
                     break;
                 case nameof(XF.StackLayout.Spacing):
-                    StackLayoutControl.Spacing = AttributeHelper.StringToDouble((string)attributeValue, 6.00);
+                    StackLayoutControl.Spacing = AttributeHelper.StringToDouble((string)attributeValue, SpacingDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StackLayoutHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StackLayoutHandler.generated.cs
@@ -9,12 +9,8 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class StackLayoutHandler : LayoutHandler
     {
-        #region Default values
-
         private static readonly XF.StackOrientation OrientationDefaultValue = XF.StackLayout.OrientationProperty.DefaultValue is XF.StackOrientation value ? value : default;
         private static readonly double SpacingDefaultValue = XF.StackLayout.SpacingProperty.DefaultValue is double value ? value : default;
-
-        #endregion Default values
 
         public StackLayoutHandler(NativeComponentRenderer renderer, XF.StackLayout stackLayoutControl) : base(renderer, stackLayoutControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.generated.cs
@@ -9,14 +9,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class StepperHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly double IncrementDefaultValue = XF.Stepper.IncrementProperty.DefaultValue is double value ? value : default;
         private static readonly double MaximumDefaultValue = XF.Stepper.MaximumProperty.DefaultValue is double value ? value : default;
         private static readonly double MinimumDefaultValue = XF.Stepper.MinimumProperty.DefaultValue is double value ? value : default;
         private static readonly double ValueDefaultValue = XF.Stepper.ValueProperty.DefaultValue is double value ? value : default;
-
-        #endregion Default values
 
         public StepperHandler(NativeComponentRenderer renderer, XF.Stepper stepperControl) : base(renderer, stepperControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/StepperHandler.generated.cs
@@ -9,6 +9,15 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class StepperHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly double IncrementDefaultValue = XF.Stepper.IncrementProperty.DefaultValue is double value ? value : default;
+        private static readonly double MaximumDefaultValue = XF.Stepper.MaximumProperty.DefaultValue is double value ? value : default;
+        private static readonly double MinimumDefaultValue = XF.Stepper.MinimumProperty.DefaultValue is double value ? value : default;
+        private static readonly double ValueDefaultValue = XF.Stepper.ValueProperty.DefaultValue is double value ? value : default;
+
+        #endregion Default values
+
         public StepperHandler(NativeComponentRenderer renderer, XF.Stepper stepperControl) : base(renderer, stepperControl)
         {
             StepperControl = stepperControl ?? throw new ArgumentNullException(nameof(stepperControl));
@@ -25,16 +34,16 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Stepper.Increment):
-                    StepperControl.Increment = AttributeHelper.StringToDouble((string)attributeValue, 1.00);
+                    StepperControl.Increment = AttributeHelper.StringToDouble((string)attributeValue, IncrementDefaultValue);
                     break;
                 case nameof(XF.Stepper.Maximum):
-                    StepperControl.Maximum = AttributeHelper.StringToDouble((string)attributeValue, 100.00);
+                    StepperControl.Maximum = AttributeHelper.StringToDouble((string)attributeValue, MaximumDefaultValue);
                     break;
                 case nameof(XF.Stepper.Minimum):
-                    StepperControl.Minimum = AttributeHelper.StringToDouble((string)attributeValue);
+                    StepperControl.Minimum = AttributeHelper.StringToDouble((string)attributeValue, MinimumDefaultValue);
                     break;
                 case nameof(XF.Stepper.Value):
-                    StepperControl.Value = AttributeHelper.StringToDouble((string)attributeValue);
+                    StepperControl.Value = AttributeHelper.StringToDouble((string)attributeValue, ValueDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.generated.cs
@@ -9,13 +9,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class SwitchHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly bool IsToggledDefaultValue = XF.Switch.IsToggledProperty.DefaultValue is bool value ? value : default;
         private static readonly XF.Color OnColorDefaultValue = XF.Switch.OnColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.Color ThumbColorDefaultValue = XF.Switch.ThumbColorProperty.DefaultValue is XF.Color value ? value : default;
-
-        #endregion Default values
 
         public SwitchHandler(NativeComponentRenderer renderer, XF.Switch switchControl) : base(renderer, switchControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/SwitchHandler.generated.cs
@@ -9,6 +9,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class SwitchHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly bool IsToggledDefaultValue = XF.Switch.IsToggledProperty.DefaultValue is bool value ? value : default;
+        private static readonly XF.Color OnColorDefaultValue = XF.Switch.OnColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.Color ThumbColorDefaultValue = XF.Switch.ThumbColorProperty.DefaultValue is XF.Color value ? value : default;
+
+        #endregion Default values
+
         public SwitchHandler(NativeComponentRenderer renderer, XF.Switch switchControl) : base(renderer, switchControl)
         {
             SwitchControl = switchControl ?? throw new ArgumentNullException(nameof(switchControl));
@@ -25,13 +33,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.Switch.IsToggled):
-                    SwitchControl.IsToggled = AttributeHelper.GetBool(attributeValue);
+                    SwitchControl.IsToggled = AttributeHelper.GetBool(attributeValue, IsToggledDefaultValue);
                     break;
                 case nameof(XF.Switch.OnColor):
-                    SwitchControl.OnColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SwitchControl.OnColor = AttributeHelper.StringToColor((string)attributeValue, OnColorDefaultValue);
                     break;
                 case nameof(XF.Switch.ThumbColor):
-                    SwitchControl.ThumbColor = AttributeHelper.StringToColor((string)attributeValue);
+                    SwitchControl.ThumbColor = AttributeHelper.StringToColor((string)attributeValue, ThumbColorDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabBarHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabBarHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TabBarHandler : ShellItemHandler
     {
+
         public TabBarHandler(NativeComponentRenderer renderer, XF.TabBar tabBarControl) : base(renderer, tabBarControl)
         {
             TabBarControl = tabBarControl ?? throw new ArgumentNullException(nameof(tabBarControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TabHandler : ShellSectionHandler
     {
+
         public TabHandler(NativeComponentRenderer renderer, XF.Tab tabControl) : base(renderer, tabControl)
         {
             TabControl = tabControl ?? throw new ArgumentNullException(nameof(tabControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.generated.cs
@@ -9,6 +9,15 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TabbedPageHandler : PageHandler
     {
+        #region Default values
+
+        private static readonly XF.Color BarBackgroundColorDefaultValue = XF.TabbedPage.BarBackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.Color BarTextColorDefaultValue = XF.TabbedPage.BarTextColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.Color SelectedTabColorDefaultValue = XF.TabbedPage.SelectedTabColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.Color UnselectedTabColorDefaultValue = XF.TabbedPage.UnselectedTabColorProperty.DefaultValue is XF.Color value ? value : default;
+
+        #endregion Default values
+
         public TabbedPageHandler(NativeComponentRenderer renderer, XF.TabbedPage tabbedPageControl) : base(renderer, tabbedPageControl)
         {
             TabbedPageControl = tabbedPageControl ?? throw new ArgumentNullException(nameof(tabbedPageControl));
@@ -25,16 +34,16 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.TabbedPage.BarBackgroundColor):
-                    TabbedPageControl.BarBackgroundColor = AttributeHelper.StringToColor((string)attributeValue);
+                    TabbedPageControl.BarBackgroundColor = AttributeHelper.StringToColor((string)attributeValue, BarBackgroundColorDefaultValue);
                     break;
                 case nameof(XF.TabbedPage.BarTextColor):
-                    TabbedPageControl.BarTextColor = AttributeHelper.StringToColor((string)attributeValue);
+                    TabbedPageControl.BarTextColor = AttributeHelper.StringToColor((string)attributeValue, BarTextColorDefaultValue);
                     break;
                 case nameof(XF.TabbedPage.SelectedTabColor):
-                    TabbedPageControl.SelectedTabColor = AttributeHelper.StringToColor((string)attributeValue);
+                    TabbedPageControl.SelectedTabColor = AttributeHelper.StringToColor((string)attributeValue, SelectedTabColorDefaultValue);
                     break;
                 case nameof(XF.TabbedPage.UnselectedTabColor):
-                    TabbedPageControl.UnselectedTabColor = AttributeHelper.StringToColor((string)attributeValue);
+                    TabbedPageControl.UnselectedTabColor = AttributeHelper.StringToColor((string)attributeValue, UnselectedTabColorDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TabbedPageHandler.generated.cs
@@ -9,14 +9,10 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TabbedPageHandler : PageHandler
     {
-        #region Default values
-
         private static readonly XF.Color BarBackgroundColorDefaultValue = XF.TabbedPage.BarBackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.Color BarTextColorDefaultValue = XF.TabbedPage.BarTextColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.Color SelectedTabColorDefaultValue = XF.TabbedPage.SelectedTabColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.Color UnselectedTabColorDefaultValue = XF.TabbedPage.UnselectedTabColorProperty.DefaultValue is XF.Color value ? value : default;
-
-        #endregion Default values
 
         public TabbedPageHandler(NativeComponentRenderer renderer, XF.TabbedPage tabbedPageControl) : base(renderer, tabbedPageControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TemplatedPageHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TemplatedPageHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TemplatedPageHandler : PageHandler
     {
+
         public TemplatedPageHandler(NativeComponentRenderer renderer, XF.TemplatedPage templatedPageControl) : base(renderer, templatedPageControl)
         {
             TemplatedPageControl = templatedPageControl ?? throw new ArgumentNullException(nameof(templatedPageControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TemplatedViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TemplatedViewHandler.generated.cs
@@ -9,6 +9,7 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TemplatedViewHandler : LayoutHandler
     {
+
         public TemplatedViewHandler(NativeComponentRenderer renderer, XF.TemplatedView templatedViewControl) : base(renderer, templatedViewControl)
         {
             TemplatedViewControl = templatedViewControl ?? throw new ArgumentNullException(nameof(templatedViewControl));

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TimePickerHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TimePickerHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TimePickerHandler : ViewHandler
     {
-        #region Default values
-
         private static readonly double CharacterSpacingDefaultValue = XF.TimePicker.CharacterSpacingProperty.DefaultValue is double value ? value : default;
         private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.TimePicker.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
         private static readonly string FontFamilyDefaultValue = XF.TimePicker.FontFamilyProperty.DefaultValue is string value ? value : default;
@@ -19,8 +17,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly XF.Color TextColorDefaultValue = XF.TimePicker.TextColorProperty.DefaultValue is XF.Color value ? value : default;
         private static readonly XF.TextTransform TextTransformDefaultValue = XF.TimePicker.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
         private static readonly TimeSpan TimeDefaultValue = XF.TimePicker.TimeProperty.DefaultValue is TimeSpan value ? value : default;
-
-        #endregion Default values
 
         public TimePickerHandler(NativeComponentRenderer renderer, XF.TimePicker timePickerControl) : base(renderer, timePickerControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TimePickerHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/TimePickerHandler.generated.cs
@@ -9,6 +9,19 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class TimePickerHandler : ViewHandler
     {
+        #region Default values
+
+        private static readonly double CharacterSpacingDefaultValue = XF.TimePicker.CharacterSpacingProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.FontAttributes FontAttributesDefaultValue = XF.TimePicker.FontAttributesProperty.DefaultValue is XF.FontAttributes value ? value : default;
+        private static readonly string FontFamilyDefaultValue = XF.TimePicker.FontFamilyProperty.DefaultValue is string value ? value : default;
+        private static readonly double FontSizeDefaultValue = XF.TimePicker.FontSizeProperty.DefaultValue is double value ? value : default;
+        private static readonly string FormatDefaultValue = XF.TimePicker.FormatProperty.DefaultValue is string value ? value : default;
+        private static readonly XF.Color TextColorDefaultValue = XF.TimePicker.TextColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.TextTransform TextTransformDefaultValue = XF.TimePicker.TextTransformProperty.DefaultValue is XF.TextTransform value ? value : default;
+        private static readonly TimeSpan TimeDefaultValue = XF.TimePicker.TimeProperty.DefaultValue is TimeSpan value ? value : default;
+
+        #endregion Default values
+
         public TimePickerHandler(NativeComponentRenderer renderer, XF.TimePicker timePickerControl) : base(renderer, timePickerControl)
         {
             TimePickerControl = timePickerControl ?? throw new ArgumentNullException(nameof(timePickerControl));
@@ -25,28 +38,28 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.TimePicker.CharacterSpacing):
-                    TimePickerControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue);
+                    TimePickerControl.CharacterSpacing = AttributeHelper.StringToDouble((string)attributeValue, CharacterSpacingDefaultValue);
                     break;
                 case nameof(XF.TimePicker.FontAttributes):
-                    TimePickerControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue);
+                    TimePickerControl.FontAttributes = (XF.FontAttributes)AttributeHelper.GetInt(attributeValue, (int)FontAttributesDefaultValue);
                     break;
                 case nameof(XF.TimePicker.FontFamily):
-                    TimePickerControl.FontFamily = (string)attributeValue;
+                    TimePickerControl.FontFamily = (string)attributeValue ?? FontFamilyDefaultValue;
                     break;
                 case nameof(XF.TimePicker.FontSize):
-                    TimePickerControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    TimePickerControl.FontSize = AttributeHelper.StringToDouble((string)attributeValue, FontSizeDefaultValue);
                     break;
                 case nameof(XF.TimePicker.Format):
-                    TimePickerControl.Format = (string)attributeValue ?? "t";
+                    TimePickerControl.Format = (string)attributeValue ?? FormatDefaultValue;
                     break;
                 case nameof(XF.TimePicker.TextColor):
-                    TimePickerControl.TextColor = AttributeHelper.StringToColor((string)attributeValue);
+                    TimePickerControl.TextColor = AttributeHelper.StringToColor((string)attributeValue, TextColorDefaultValue);
                     break;
                 case nameof(XF.TimePicker.TextTransform):
-                    TimePickerControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)XF.TextTransform.Default);
+                    TimePickerControl.TextTransform = (XF.TextTransform)AttributeHelper.GetInt(attributeValue, (int)TextTransformDefaultValue);
                     break;
                 case nameof(XF.TimePicker.Time):
-                    TimePickerControl.Time = AttributeHelper.StringToTimeSpan(attributeValue);
+                    TimePickerControl.Time = AttributeHelper.StringToTimeSpan(attributeValue, TimeDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ViewHandler.generated.cs
@@ -9,6 +9,14 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ViewHandler : VisualElementHandler
     {
+        #region Default values
+
+        private static readonly XF.LayoutOptions HorizontalOptionsDefaultValue = XF.View.HorizontalOptionsProperty.DefaultValue is XF.LayoutOptions value ? value : default;
+        private static readonly XF.Thickness MarginDefaultValue = XF.View.MarginProperty.DefaultValue is XF.Thickness value ? value : default;
+        private static readonly XF.LayoutOptions VerticalOptionsDefaultValue = XF.View.VerticalOptionsProperty.DefaultValue is XF.LayoutOptions value ? value : default;
+
+        #endregion Default values
+
         public ViewHandler(NativeComponentRenderer renderer, XF.View viewControl) : base(renderer, viewControl)
         {
             ViewControl = viewControl ?? throw new ArgumentNullException(nameof(viewControl));
@@ -25,13 +33,13 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.View.HorizontalOptions):
-                    ViewControl.HorizontalOptions = AttributeHelper.StringToLayoutOptions(attributeValue, XF.LayoutOptions.Fill);
+                    ViewControl.HorizontalOptions = AttributeHelper.StringToLayoutOptions(attributeValue, HorizontalOptionsDefaultValue);
                     break;
                 case nameof(XF.View.Margin):
-                    ViewControl.Margin = AttributeHelper.StringToThickness(attributeValue);
+                    ViewControl.Margin = AttributeHelper.StringToThickness(attributeValue, MarginDefaultValue);
                     break;
                 case nameof(XF.View.VerticalOptions):
-                    ViewControl.VerticalOptions = AttributeHelper.StringToLayoutOptions(attributeValue, XF.LayoutOptions.Fill);
+                    ViewControl.VerticalOptions = AttributeHelper.StringToLayoutOptions(attributeValue, VerticalOptionsDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ViewHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/ViewHandler.generated.cs
@@ -9,13 +9,9 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class ViewHandler : VisualElementHandler
     {
-        #region Default values
-
         private static readonly XF.LayoutOptions HorizontalOptionsDefaultValue = XF.View.HorizontalOptionsProperty.DefaultValue is XF.LayoutOptions value ? value : default;
         private static readonly XF.Thickness MarginDefaultValue = XF.View.MarginProperty.DefaultValue is XF.Thickness value ? value : default;
         private static readonly XF.LayoutOptions VerticalOptionsDefaultValue = XF.View.VerticalOptionsProperty.DefaultValue is XF.LayoutOptions value ? value : default;
-
-        #endregion Default values
 
         public ViewHandler(NativeComponentRenderer renderer, XF.View viewControl) : base(renderer, viewControl)
         {

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.generated.cs
@@ -9,6 +9,33 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class VisualElementHandler : NavigableElementHandler
     {
+        #region Default values
+
+        private static readonly double AnchorXDefaultValue = XF.VisualElement.AnchorXProperty.DefaultValue is double value ? value : default;
+        private static readonly double AnchorYDefaultValue = XF.VisualElement.AnchorYProperty.DefaultValue is double value ? value : default;
+        private static readonly XF.Color BackgroundColorDefaultValue = XF.VisualElement.BackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
+        private static readonly XF.FlowDirection FlowDirectionDefaultValue = XF.VisualElement.FlowDirectionProperty.DefaultValue is XF.FlowDirection value ? value : default;
+        private static readonly double HeightRequestDefaultValue = XF.VisualElement.HeightRequestProperty.DefaultValue is double value ? value : default;
+        private static readonly bool InputTransparentDefaultValue = XF.VisualElement.InputTransparentProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsEnabledDefaultValue = XF.VisualElement.IsEnabledProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsTabStopDefaultValue = XF.VisualElement.IsTabStopProperty.DefaultValue is bool value ? value : default;
+        private static readonly bool IsVisibleDefaultValue = XF.VisualElement.IsVisibleProperty.DefaultValue is bool value ? value : default;
+        private static readonly double MinimumHeightRequestDefaultValue = XF.VisualElement.MinimumHeightRequestProperty.DefaultValue is double value ? value : default;
+        private static readonly double MinimumWidthRequestDefaultValue = XF.VisualElement.MinimumWidthRequestProperty.DefaultValue is double value ? value : default;
+        private static readonly double OpacityDefaultValue = XF.VisualElement.OpacityProperty.DefaultValue is double value ? value : default;
+        private static readonly double RotationDefaultValue = XF.VisualElement.RotationProperty.DefaultValue is double value ? value : default;
+        private static readonly double RotationXDefaultValue = XF.VisualElement.RotationXProperty.DefaultValue is double value ? value : default;
+        private static readonly double RotationYDefaultValue = XF.VisualElement.RotationYProperty.DefaultValue is double value ? value : default;
+        private static readonly double ScaleDefaultValue = XF.VisualElement.ScaleProperty.DefaultValue is double value ? value : default;
+        private static readonly double ScaleXDefaultValue = XF.VisualElement.ScaleXProperty.DefaultValue is double value ? value : default;
+        private static readonly double ScaleYDefaultValue = XF.VisualElement.ScaleYProperty.DefaultValue is double value ? value : default;
+        private static readonly int TabIndexDefaultValue = XF.VisualElement.TabIndexProperty.DefaultValue is int value ? value : default;
+        private static readonly double TranslationXDefaultValue = XF.VisualElement.TranslationXProperty.DefaultValue is double value ? value : default;
+        private static readonly double TranslationYDefaultValue = XF.VisualElement.TranslationYProperty.DefaultValue is double value ? value : default;
+        private static readonly double WidthRequestDefaultValue = XF.VisualElement.WidthRequestProperty.DefaultValue is double value ? value : default;
+
+        #endregion Default values
+
         public VisualElementHandler(NativeComponentRenderer renderer, XF.VisualElement visualElementControl) : base(renderer, visualElementControl)
         {
             VisualElementControl = visualElementControl ?? throw new ArgumentNullException(nameof(visualElementControl));
@@ -25,70 +52,70 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
             switch (attributeName)
             {
                 case nameof(XF.VisualElement.AnchorX):
-                    VisualElementControl.AnchorX = AttributeHelper.StringToDouble((string)attributeValue, 0.50);
+                    VisualElementControl.AnchorX = AttributeHelper.StringToDouble((string)attributeValue, AnchorXDefaultValue);
                     break;
                 case nameof(XF.VisualElement.AnchorY):
-                    VisualElementControl.AnchorY = AttributeHelper.StringToDouble((string)attributeValue, 0.50);
+                    VisualElementControl.AnchorY = AttributeHelper.StringToDouble((string)attributeValue, AnchorYDefaultValue);
                     break;
                 case nameof(XF.VisualElement.BackgroundColor):
-                    VisualElementControl.BackgroundColor = AttributeHelper.StringToColor((string)attributeValue);
+                    VisualElementControl.BackgroundColor = AttributeHelper.StringToColor((string)attributeValue, BackgroundColorDefaultValue);
                     break;
                 case nameof(XF.VisualElement.FlowDirection):
-                    VisualElementControl.FlowDirection = (XF.FlowDirection)AttributeHelper.GetInt(attributeValue);
+                    VisualElementControl.FlowDirection = (XF.FlowDirection)AttributeHelper.GetInt(attributeValue, (int)FlowDirectionDefaultValue);
                     break;
                 case nameof(XF.VisualElement.HeightRequest):
-                    VisualElementControl.HeightRequest = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    VisualElementControl.HeightRequest = AttributeHelper.StringToDouble((string)attributeValue, HeightRequestDefaultValue);
                     break;
                 case nameof(XF.VisualElement.InputTransparent):
-                    VisualElementControl.InputTransparent = AttributeHelper.GetBool(attributeValue);
+                    VisualElementControl.InputTransparent = AttributeHelper.GetBool(attributeValue, InputTransparentDefaultValue);
                     break;
                 case nameof(XF.VisualElement.IsEnabled):
-                    VisualElementControl.IsEnabled = AttributeHelper.GetBool(attributeValue, true);
+                    VisualElementControl.IsEnabled = AttributeHelper.GetBool(attributeValue, IsEnabledDefaultValue);
                     break;
                 case nameof(XF.VisualElement.IsTabStop):
-                    VisualElementControl.IsTabStop = AttributeHelper.GetBool(attributeValue, true);
+                    VisualElementControl.IsTabStop = AttributeHelper.GetBool(attributeValue, IsTabStopDefaultValue);
                     break;
                 case nameof(XF.VisualElement.IsVisible):
-                    VisualElementControl.IsVisible = AttributeHelper.GetBool(attributeValue, true);
+                    VisualElementControl.IsVisible = AttributeHelper.GetBool(attributeValue, IsVisibleDefaultValue);
                     break;
                 case nameof(XF.VisualElement.MinimumHeightRequest):
-                    VisualElementControl.MinimumHeightRequest = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    VisualElementControl.MinimumHeightRequest = AttributeHelper.StringToDouble((string)attributeValue, MinimumHeightRequestDefaultValue);
                     break;
                 case nameof(XF.VisualElement.MinimumWidthRequest):
-                    VisualElementControl.MinimumWidthRequest = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    VisualElementControl.MinimumWidthRequest = AttributeHelper.StringToDouble((string)attributeValue, MinimumWidthRequestDefaultValue);
                     break;
                 case nameof(XF.VisualElement.Opacity):
-                    VisualElementControl.Opacity = AttributeHelper.StringToDouble((string)attributeValue, 1.00);
+                    VisualElementControl.Opacity = AttributeHelper.StringToDouble((string)attributeValue, OpacityDefaultValue);
                     break;
                 case nameof(XF.VisualElement.Rotation):
-                    VisualElementControl.Rotation = AttributeHelper.StringToDouble((string)attributeValue);
+                    VisualElementControl.Rotation = AttributeHelper.StringToDouble((string)attributeValue, RotationDefaultValue);
                     break;
                 case nameof(XF.VisualElement.RotationX):
-                    VisualElementControl.RotationX = AttributeHelper.StringToDouble((string)attributeValue);
+                    VisualElementControl.RotationX = AttributeHelper.StringToDouble((string)attributeValue, RotationXDefaultValue);
                     break;
                 case nameof(XF.VisualElement.RotationY):
-                    VisualElementControl.RotationY = AttributeHelper.StringToDouble((string)attributeValue);
+                    VisualElementControl.RotationY = AttributeHelper.StringToDouble((string)attributeValue, RotationYDefaultValue);
                     break;
                 case nameof(XF.VisualElement.Scale):
-                    VisualElementControl.Scale = AttributeHelper.StringToDouble((string)attributeValue, 1.00);
+                    VisualElementControl.Scale = AttributeHelper.StringToDouble((string)attributeValue, ScaleDefaultValue);
                     break;
                 case nameof(XF.VisualElement.ScaleX):
-                    VisualElementControl.ScaleX = AttributeHelper.StringToDouble((string)attributeValue, 1.00);
+                    VisualElementControl.ScaleX = AttributeHelper.StringToDouble((string)attributeValue, ScaleXDefaultValue);
                     break;
                 case nameof(XF.VisualElement.ScaleY):
-                    VisualElementControl.ScaleY = AttributeHelper.StringToDouble((string)attributeValue, 1.00);
+                    VisualElementControl.ScaleY = AttributeHelper.StringToDouble((string)attributeValue, ScaleYDefaultValue);
                     break;
                 case nameof(XF.VisualElement.TabIndex):
-                    VisualElementControl.TabIndex = AttributeHelper.GetInt(attributeValue);
+                    VisualElementControl.TabIndex = AttributeHelper.GetInt(attributeValue, TabIndexDefaultValue);
                     break;
                 case nameof(XF.VisualElement.TranslationX):
-                    VisualElementControl.TranslationX = AttributeHelper.StringToDouble((string)attributeValue);
+                    VisualElementControl.TranslationX = AttributeHelper.StringToDouble((string)attributeValue, TranslationXDefaultValue);
                     break;
                 case nameof(XF.VisualElement.TranslationY):
-                    VisualElementControl.TranslationY = AttributeHelper.StringToDouble((string)attributeValue);
+                    VisualElementControl.TranslationY = AttributeHelper.StringToDouble((string)attributeValue, TranslationYDefaultValue);
                     break;
                 case nameof(XF.VisualElement.WidthRequest):
-                    VisualElementControl.WidthRequest = AttributeHelper.StringToDouble((string)attributeValue, -1.00);
+                    VisualElementControl.WidthRequest = AttributeHelper.StringToDouble((string)attributeValue, WidthRequestDefaultValue);
                     break;
                 default:
                     base.ApplyAttribute(attributeEventHandlerId, attributeName, attributeValue, attributeEventUpdatesAttributeName);

--- a/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.generated.cs
+++ b/src/Microsoft.MobileBlazorBindings/Elements/Handlers/VisualElementHandler.generated.cs
@@ -9,8 +9,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
 {
     public partial class VisualElementHandler : NavigableElementHandler
     {
-        #region Default values
-
         private static readonly double AnchorXDefaultValue = XF.VisualElement.AnchorXProperty.DefaultValue is double value ? value : default;
         private static readonly double AnchorYDefaultValue = XF.VisualElement.AnchorYProperty.DefaultValue is double value ? value : default;
         private static readonly XF.Color BackgroundColorDefaultValue = XF.VisualElement.BackgroundColorProperty.DefaultValue is XF.Color value ? value : default;
@@ -33,8 +31,6 @@ namespace Microsoft.MobileBlazorBindings.Elements.Handlers
         private static readonly double TranslationXDefaultValue = XF.VisualElement.TranslationXProperty.DefaultValue is double value ? value : default;
         private static readonly double TranslationYDefaultValue = XF.VisualElement.TranslationYProperty.DefaultValue is double value ? value : default;
         private static readonly double WidthRequestDefaultValue = XF.VisualElement.WidthRequestProperty.DefaultValue is double value ? value : default;
-
-        #endregion Default values
 
         public VisualElementHandler(NativeComponentRenderer renderer, XF.VisualElement visualElementControl) : base(renderer, visualElementControl)
         {


### PR DESCRIPTION
Contributes to #309 (.1)

Currently Generator retrieves actual BindableProperty's DefaultValue, and attempts to generate expression for this value. 
This approach has multiple issues:
- Ability to generate expressions for values is limited (and not really easy).
- Retrieving actual BindableProperty is not very reliable, e.g. it fails for some Xamarin Community Toolkit controls (because of Device.GetNamedSize usage).
- It's not possible to use Source Generator approach (if we decide to go this way).


This PR replaces expressions generation with simply using BindableProperty's DefaultValue in runtime (I assign them to static readonly fields in Handlers).